### PR TITLE
Removed "foreign key" property of "email" field in eventsignups

### DIFF
--- a/amivapi/models.py
+++ b/amivapi/models.py
@@ -438,7 +438,7 @@ class EventSignup(Base):
 
     event_id = Column(Integer, ForeignKey("events.id"), nullable=False)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
-    email = Column(CHAR(100), ForeignKey("users.email"))
+    email = Column(CHAR(100))
     additional_fields = Column(Text)
 
     """for unregistered users"""

--- a/amivapi/schemas.py
+++ b/amivapi/schemas.py
@@ -139,9 +139,6 @@ def get_domain():
         'only_anonymous': True,
         'email_signup_must_be_allowed': True})
 
-    # Since the data relation is not evaluated for posting, we need to remove
-    # it from the schema TODO: EXPLAIN BETTER
-    del(domain['eventsignups']['schema']['email']['data_relation'])
     # Remove _email_unreg and _token from the schema since they are only
     # for internal use and should not be visible
     del(domain['eventsignups']['schema']['_email_unreg'])


### PR DESCRIPTION
Not sure why it needed to be there anyways.

It seems to not break anything, but maybe we have some untested functionality here?

Hermann, you added this: Is this field necessary for something I cant see?