### PR TITLE
Added show_website flag to joboffers and reworked other fields

### DIFF
--- a/amivapi/joboffers/__init__.py
+++ b/amivapi/joboffers/__init__.py
@@ -28,43 +28,46 @@ jobdomain = {
 
         'schema': {
             'company': {
-                'required': True,
                 'maxlength': 30,
-                'nullable': True,
                 'type': 'string',
-                # This is basically here, because this is a required
-                # field. It will make sure there is always either an english
-                # or a german title
-                'depends_any': ['title_de', 'title_en']
             },
             'description_de': {
-                'nullable': True,
                 'type': 'string',
-                'unique': False
             },
             'description_en': {
-                'nullable': True,
                 'type': 'string'
             },
             'logo': {
                 'filetype': ['png', 'jpeg'],
-                'type': 'media'
+                'type': 'media',
+                'required': True
             },
             'pdf': {
                 'filetype': ['pdf'],
-                'type': 'media'
+                'type': 'media',
+                'required': True
             },
             'time_end': {
-                'nullable': True,
                 'type': 'datetime'
             },
             'title_de': {
-                'nullable': True,
-                'type': 'string'
+                'type': 'string',
+                'required_if_not': 'title_en',
+                'dependencies': 'description_de'
             },
             'title_en': {
-                'nullable': True,
-                'type': 'string'
+                'type': 'string',
+                'required_if_not': 'title_de',
+                'dependencies': 'description_en'
+            },
+            'show_website': {
+                'type': 'boolean',
+                # TODO: Activate this, when it is possible to post files and
+                # boolean in the same request
+                # Currently this is not possible and therefore this would
+                # prevent POST to /joboffers
+                # 'required': True,
+                'default': False
             }
         }
     }

--- a/amivapi/tests/fixtures.py
+++ b/amivapi/tests/fixtures.py
@@ -273,6 +273,9 @@ class FixtureMixin(object):
         obj.setdefault(
             'title_de',
             self.create_random_value(schema['title_de']))
+        obj.setdefault(
+            'description_de',
+            self.create_random_value(schema['description_de']))
 
     def create_random_value(self, definition):
         """Create a random value for the given cerberus field description."""
@@ -329,7 +332,7 @@ class FixtureMixin(object):
 
         elif t == 'media':
             ftype = random.choice(definition.get('filetype', ['zip']))
-            if ftype == 'jpg':
+            if ftype == 'jpg' or ftype == 'jpeg':
                 return FileStorage(open(jpgpath, 'rb'), 'test.jpg')
             if ftype == 'png':
                 return FileStorage(open(pngpath, 'rb'), 'test.png')

--- a/amivapi/tests/joboffers/test_joboffers.py
+++ b/amivapi/tests/joboffers/test_joboffers.py
@@ -5,9 +5,14 @@
 """Tests for purchases module"""
 
 from datetime import datetime, timedelta
+from io import BytesIO
+from os.path import join, dirname
 
 from amivapi.tests import utils
 from amivapi.settings import DATE_FORMAT
+
+pdfpath = join(dirname(__file__), "../fixtures", 'test.pdf')
+lenapath = join(dirname(__file__), "../fixtures", 'lena.png')
 
 
 class JobOffersTest(utils.WebTestNoAuth):
@@ -34,10 +39,14 @@ class JobOffersTest(utils.WebTestNoAuth):
             'time_end': time_end,
             'title_de': 'ACME Inc jetzt auf der Suche nach Explosionsexperte',
             'title_en': 'ACME Inc now hiring explosions experts',
+            'pdf': (BytesIO(br'%PDF magic'), 'test.pdf'),
+            'logo': (open(lenapath, 'rb'), 'logo.png'),
         }
 
         # Check if posting the joboffer is successful
-        self.api.post("/joboffers", data=post_data, status_code=201)
+        self.api.post("/joboffers",
+                      headers={'content-type': 'multipart/form-data'},
+                      data=post_data, status_code=201)
 
     def test_get_joboffer(self):
         """Usecase: User wants to see a job offer listing
@@ -51,6 +60,7 @@ class JobOffersTest(utils.WebTestNoAuth):
             'joboffers',
             company='ACME Inc.',
             title_en="ACME Wants engineers",
+            description_en="ACME needs your life",
             time_end=expired_time
         )
 
@@ -68,6 +78,7 @@ class JobOffersTest(utils.WebTestNoAuth):
             'joboffers',
             company='AMIV Inc.',
             title_en="ACME wants more engineers",
+            description_en="ACME need you life",
             time_end=valid_time
         )
 


### PR DESCRIPTION
We discussed the requirements of job offers.
It was decided, that any joboffer will always have a pdf and a company logo, therefore we can make them required. This makes integration with CRM and displaying more reliable as well.

In addition we want a flag, that controls whether the job offer is shown on the website. This is important, as some companies want to take a job offer offline, when the job is given to someone. In addition we would like a possibility in the future, where companies can create joboffers themselves on the kontakt page. That means we want to review them before publishing, which we can, if the flag can prevent it from being shown.