### PR TITLE
Improvements of signups

### DIFF
--- a/amivapi/events/__init__.py
+++ b/amivapi/events/__init__.py
@@ -33,8 +33,7 @@ from .queue import (
     add_accepted_before_insert_collection,
     update_waiting_list_after_insert,
     update_waiting_list_after_insert_collection,
-    update_waiting_list_after_delete,
-    update_waiting_list_after_delete_collection
+    update_waiting_list_after_delete
 )
 
 
@@ -71,6 +70,5 @@ def init_app(app):
     app.on_inserted_item_eventsignups += update_waiting_list_after_insert
     app.on_inserted_eventsignups += update_waiting_list_after_insert_collection
     app.on_deleted_item_eventsignups += update_waiting_list_after_delete
-    app.on_deleted_eventsignups += update_waiting_list_after_delete_collection
 
     app.register_blueprint(email_blueprint)

--- a/amivapi/events/__init__.py
+++ b/amivapi/events/__init__.py
@@ -21,12 +21,20 @@ from .projections import (
     add_signup_count_to_event_collection
 )
 from .validation import EventValidator
-from .email_confirmations import (
-    confirmprint,
+from .emails import (
+    email_blueprint,
     send_confirmmail_to_unregistered_users,
     send_confirmmail_to_unregistered_users_bulk,
     add_confirmed_before_insert,
     add_confirmed_before_insert_bulk
+)
+from .queue import (
+    add_accepted_before_insert,
+    add_accepted_before_insert_collection,
+    update_waiting_list_after_insert,
+    update_waiting_list_after_insert_collection,
+    update_waiting_list_after_delete,
+    update_waiting_list_after_delete_collection
 )
 
 
@@ -55,4 +63,14 @@ def init_app(app):
     app.on_inserted_item_eventsignups += send_confirmmail_to_unregistered_users
     app.on_inserted_eventsignups += send_confirmmail_to_unregistered_users_bulk
 
-    app.register_blueprint(confirmprint)
+    # Auto accept registrations for fcfs system
+    app.on_insert_item_eventsignups += add_accepted_before_insert
+    app.on_insert_eventsignups += add_accepted_before_insert_collection
+
+    # Update waiting list after insert or delete of signups
+    app.on_inserted_item_eventsignups += update_waiting_list_after_insert
+    app.on_inserted_eventsignups += update_waiting_list_after_insert_collection
+    app.on_deleted_item_eventsignups += update_waiting_list_after_delete
+    app.on_deleted_eventsignups += update_waiting_list_after_delete_collection
+
+    app.register_blueprint(email_blueprint)

--- a/amivapi/events/__init__.py
+++ b/amivapi/events/__init__.py
@@ -11,7 +11,7 @@ logic needed for signup of non members to events.
 from amivapi.utils import register_domain, register_validator
 
 from .model import eventdomain
-
+from .authorization import EventAuthValidator
 from .projections import (
     add_email_to_signup,
     add_email_to_signup_collection,
@@ -34,6 +34,7 @@ def init_app(app):
     """Register resources and blueprints, add hooks and validation."""
     register_domain(app, eventdomain)
     register_validator(app, EventValidator)
+    register_validator(app, EventAuthValidator)
 
     # Show user's email in registered signups
     app.on_fetched_resource_eventsignups += add_email_to_signup_collection

--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -181,7 +181,7 @@ eventdomain = {
             },
             'additional_fields': {
                 'nullable': True,
-                'type': 'json_schema',
+                'type': 'cerberus_schema',
                 'only_if_not_null': 'spots'
             },
             'allow_email_signup': {
@@ -213,7 +213,8 @@ eventdomain = {
             'the registration-window. External Users can only sign up to '
             'public events.',
             'methods': {
-                'PATCH': 'Only additional_fields can be changed'
+                'PATCH': 'Only additional_fields can be changed by users. '
+                'Admins can also patch accepted.'
             }
         },
 
@@ -234,8 +235,6 @@ eventdomain = {
                 'required': True,
                 'signup_requirements': True,
                 'type': 'objectid',
-                'unique_combination': ['user',
-                                       'email'],
             },
             'user': {
                 'data_relation': {
@@ -246,6 +245,7 @@ eventdomain = {
                 'only_self_enrollment_for_event': True,
                 'type': 'objectid',
                 'nullable': False,
+                'unique_combination': ['event']
 
                 # This creates a presence XOR with email
                 # TODO: This needs cerberus > 1.0.1
@@ -264,6 +264,7 @@ eventdomain = {
                 'nullable': False,
                 'regex': EMAIL_REGEX,
                 'type': 'string',
+                'unique_combination': ['event']
 
                 # This creates a presence XOR with user
                 # TODO: This needs cerberus > 1.0.1

--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -160,7 +160,8 @@ eventdomain = {
 
             'spots': {
                 'dependencies': ['time_register_start',
-                                 'time_register_end'],
+                                 'time_register_end',
+                                 'selection_strategy'],
                 'min': 0,
                 'nullable': True,
                 'type': 'integer',
@@ -191,6 +192,12 @@ eventdomain = {
                 'only_if_not_null': 'spots'
             },
 
+            'selection_strategy': {
+                'type': 'string',
+                'allowed': ['fcfs', 'manual'],
+                'only_if_not_null': 'spots'
+            },
+
             'signup_count': {
                 'readonly': True,
                 'type': 'integer'
@@ -207,7 +214,16 @@ eventdomain = {
                 'email': 'For registered users, this is just a projection of '
                 'your general email-address. External users need to provide '
                 'their email here.',
-                'user': "Provide either user or email."
+                'user': "Provide either user or email.",
+                'confirmed': "This fields describes, whether the email address "
+                "was validated. This is automatically set for registered users "
+                "and will be True after the user has clicked the confirmation "
+                "link for unregistered users.",
+                'accepted': "This field describes, whether a user is in the "
+                "accepted list of people for the event or on the waiting list. "
+                "Depending on the `selection_method` field of the parent event,"
+                " this field is automatically set to True for new signups, as "
+                "long as there is space, or needs to be set by an admin."
             },
             'general': 'You can signup here for an existing event inside of '
             'the registration-window. External Users can only sign up to '
@@ -273,9 +289,12 @@ eventdomain = {
                 # 'excludes': ['user']
             },
             'confirmed': {
-                'nullable': True,
                 'type': 'boolean',
                 'readonly': True
+            },
+            'accepted': {
+                'type': 'boolean',
+                'admin_only': True
             },
         }
     }

--- a/amivapi/events/queue.py
+++ b/amivapi/events/queue.py
@@ -120,9 +120,3 @@ def update_waiting_list_after_delete(signup):
         return
 
     update_waiting_list(signup['event'])
-
-
-def update_waiting_list_after_delete_collection(signups):
-    """Call item hook for collection endpoint"""
-    for s in signups:
-        update_waiting_list_after_delete(s)

--- a/amivapi/events/queue.py
+++ b/amivapi/events/queue.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+#
+# license: AGPLv3, see LICENSE for details. In addition we strongly encourage
+#          you to buy us beer if we meet and you like the software.
+"""Logic to implement different signup queues
+"""
+
+from flask import current_app, url_for
+from itsdangerous import Signer
+from pymongo import ASCENDING
+
+from amivapi.utils import mail
+
+
+def update_waiting_list(event_id):
+    """Fill up missing people in an event with people from the waiting list.
+    This gets triggered by different hooks, whenever the list needs to be
+    updated.
+
+    1. After a new signup is created.
+    2. After a signup was deleted.
+    3. After an external signup was confirmed.
+    """
+    id_field = current_app.config['ID_FIELD']
+    lookup = {id_field: event_id}
+    event = current_app.data.find_one('events', None, **lookup)
+
+    if event['selection_strategy'] == 'fcfs':
+        lookup = {'event': event_id, 'accepted': True}
+        signup_count = current_app.data.driver.db['eventsignups'].find(
+            lookup).count()
+
+        if signup_count < event['spots']:
+            lookup = {'event': event_id, 'accepted': False, 'confirmed': True}
+            new_list = current_app.data.driver.db['eventsignups'].find(
+                lookup).sort('_created', ASCENDING)
+
+            for new_accepted in new_list.limit(event['spots'] - signup_count):
+                # Set accepted flag
+                current_app.data.update('eventsignups', new_accepted[id_field],
+                                        {'accepted': True}, new_accepted)
+
+                # Notify user
+                title = event.get('title_en', event.get('title_de'))
+                notify_signup_accepted(title, new_accepted)
+
+
+def notify_signup_accepted(event_name, signup):
+    """Send an email to a user, that his signup was accepted"""
+    id_field = current_app.config['ID_FIELD']
+
+    if signup.get('user'):
+        lookup = {id_field: signup['user']}
+        user = current_app.data.find_one('users', None, **lookup)
+        name = user['firstname']
+        email = user['email']
+    else:
+        name = 'Guest of AMIV'
+        email = signup['email']
+
+    token = Signer(current_app.config['TOKEN_SECRET']).sign(
+            str(signup[id_field]).encode('utf-8'))
+
+    if current_app.config.get('SERVER_NAME') is None:
+        current_app.logger.warning("SERVER_NAME is not set. E-Mail links "
+                                   "will not work!")
+
+    deletion_link = url_for('emails.on_delete_signup', token=token,
+                            _external=True)
+
+    mail(current_app.config['API_MAIL'], email,
+         '[AMIV] Eventsignup accepted',
+         'Hello %s!\n'
+         '\n'
+         'We are happy to inform you that your signup for %s was accepted and '
+         'you can come to the event! If you do not have time to attend the '
+         'event please click this link to free your spot for someone else:\n'
+         '\n%s\n\n'
+         'Best Regards,\n'
+         'The AMIV event bot'
+         % (name, event_name, deletion_link))
+
+
+"""
+Hooks that trigger fcfs execution
+"""
+
+
+def add_accepted_before_insert(signup):
+    """Add the accepted field before inserting signups"""
+    signup['accepted'] = False
+
+
+def add_accepted_before_insert_collection(signups):
+    """Trigger item hook in loop for collection"""
+    for s in signups:
+        add_accepted_before_insert(s)
+
+
+def update_waiting_list_after_insert(signup):
+    """Hook to automatically update the waiting list, when new signups are
+    created. This way users get accepted, when fcfs is used and the event is not
+    full yet."""
+    update_waiting_list(signup['event'])
+
+
+def update_waiting_list_after_insert_collection(signups):
+    """Call the auto_accept_fcfs_signup hook for bulk inserts. This could be
+    optimized if multiple signups are for the same event, however we do not
+    know that, so this just loop over them and calls the hook for each item."""
+    for s in signups:
+        update_waiting_list_after_insert(s)
+
+
+def update_waiting_list_after_delete(signup):
+    """Hook, called when a signup was deleted, to update the waiting list of
+    the associated event"""
+    if not signup['accepted']:
+        # User was on the waitinglist, so nothing changes
+        return
+
+    update_waiting_list(signup['event'])
+
+
+def update_waiting_list_after_delete_collection(signups):
+    """Call item hook for collection endpoint"""
+    for s in signups:
+        update_waiting_list_after_delete(s)

--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -71,6 +71,7 @@ CONFIRM_EMAIL_TEXT = (
 
 # Signup confirmation without redirct
 CONFIRM_TEXT = "Your singup was confirmed!"
+SIGNUP_DELETED_TEXT = "Your signup was removed."
 
 # All organisational units (ou) in ldap which are assigned to AMIV (by VSETH)
 LDAP_MEMBER_OU_LIST = [

--- a/amivapi/tests/events/test_model.py
+++ b/amivapi/tests/events/test_model.py
@@ -51,6 +51,12 @@ class EventModelTest(WebTestNoAuth):
         self.api.post("/eventsignups", data={
             'user': str(user['_id']),
             'event': str(ev['_id']),
+            'additional_fields': "{not even json}"
+        }, status_code=422)
+
+        self.api.post("/eventsignups", data={
+            'user': str(user['_id']),
+            'event': str(ev['_id']),
             'additional_fields': json.dumps({
                 'field1': 'aaaaaaaaaaaaaaaaaaaaa',
                 'field2': 0
@@ -100,3 +106,19 @@ class EventModelTest(WebTestNoAuth):
 
             data['spots'] = None
             self.api.post('/events', data=data, status_code=422)
+
+    def test_eventsignup_validators_work_without_event(self):
+        """Test that none of the validators of eventsignups crash without an
+        event"""
+        user = self.new_object('users')
+
+        self.api.post('/eventsignups', data={
+            'user': str(user['_id']),
+            'additional_fields': "{}"
+        }, status_code=422)
+
+        self.api.post('/eventsignups', data={
+            'event': 'invalid',
+            'user': str(user['_id']),
+            'additional_fields': "{}"
+        }, status_code=422)

--- a/amivapi/tests/events/test_model.py
+++ b/amivapi/tests/events/test_model.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+#
+# license: AGPLv3, see LICENSE for details. In addition we strongly encourage
+#          you to buy us beer if we meet and you like the software.
+
+"""Test event model specific validators."""
+
+import json
+
+from amivapi.tests.utils import WebTestNoAuth
+
+
+class EventModelTest(WebTestNoAuth):
+    """Test class for event model specific validators."""
+
+    def event_data(self, data):
+        """Add minimum needed data for an event (descriptions)."""
+        return dict(title_en='party',
+                    description_en='fun',
+                    catchphrase_en='disco, disco, party, party',
+                    time_advertising_start='1970-01-01T00:00:01Z',
+                    time_advertising_end='2020-01-01T00:00:00Z',
+                    priority=5,
+                    **data)
+
+    def test_signup_to_event_without_signup(self):
+        """Test that signups to events without a signup are rejected."""
+        ev = self.new_object("events", spots=None)
+        user = self.new_object("users")
+
+        self.api.post("/eventsignups", data={
+            'event': str(ev['_id']),
+            'user': str(user['_id'])
+        }, status_code=422)
+
+    def test_additional_fields_must_match(self):
+        """Test the validation of additional fields."""
+        ev = self.new_object("events", spots=100,
+                             additional_fields=json.dumps({
+                                 'field1': {
+                                     'type': 'string',
+                                     'maxlength': 10
+                                 },
+                                 'field2': {
+                                     'type': 'integer'
+                                 }
+                             }))
+
+        user = self.new_object("users")
+
+        self.api.post("/eventsignups", data={
+            'user': str(user['_id']),
+            'event': str(ev['_id']),
+            'additional_fields': json.dumps({
+                'field1': 'aaaaaaaaaaaaaaaaaaaaa',
+                'field2': 0
+            })
+        }, status_code=422)
+
+        self.api.post("/eventsignups", data={
+            'user': str(user['_id']),
+            'event': str(ev['_id']),
+            'additional_fields': json.dumps({
+                'field1': 'asdasdasd',
+                'field2': 50
+            })
+        }, status_code=201)
+
+    def test_email_signup_only_when_allowed(self):
+        """Test that email signup is only possible if enabled."""
+        ev = self.new_object("events", spots=100, allow_email_signup=False)
+        self.api.post("/eventsignups", data={
+            'email': 'bla@bla.org',
+            'event': str(ev['_id'])
+        }, status_code=422)
+
+        ev = self.new_object("events", spots=100, allow_email_signup=True)
+        self.api.post("/eventsignups", data={
+            'email': 'bla@bla.org',
+            'event': str(ev['_id'])
+        }, status_code=201)
+
+    def test_spots_none(self):
+        """Test you can set spots to None and this does not require deps."""
+        self.api.post('/events', data=self.event_data({
+            'spots': None,
+        }), status_code=201)
+
+    def test_fields_depending_on_signup_not_null(self):
+        """Test that signup needs to be not None for fields depending on it."""
+        test_data = [
+            {'allow_email_signup': True},
+            {'additional_fields': ''},
+            {'time_register_start': '2016-10-17T21:11:14Z'},
+        ]
+        # No need to test time end, this depends on time start anyway.
+
+        for data in test_data:
+            data = self.event_data(data)
+
+            data['spots'] = None
+            self.api.post('/events', data=data, status_code=422)

--- a/amivapi/tests/events/test_projections.py
+++ b/amivapi/tests/events/test_projections.py
@@ -79,6 +79,12 @@ class EventProjectionTest(WebTestNoAuth):
                               status_code=200).json
         self.assertEqual(signup['email'], 'testemail@amiv.com')
 
+        # Check again with embedding of user
+        signup = self.api.get('/eventsignups/%s?embedded={"user":1}'
+                              % signup['_id'],
+                              status_code=200).json
+        self.assertEqual(signup['email'], 'testemail@amiv.com')
+
     def test_confirmed_projected(self):
         """Test that an external signups gets the confirmed field"""
         event = self.new_object('events', spots=100, additional_fields=None,

--- a/amivapi/tests/events/test_queue.py
+++ b/amivapi/tests/events/test_queue.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# license: AGPLv3, see LICENSE for details. In addition we strongly encourage
+#          you to buy us beer if we meet and you like the software.
+"""Test that people are correctly added and removed from the waiting list"""
+
+from amivapi.tests.utils import WebTestNoAuth
+
+
+class EventsignupQueueTest(WebTestNoAuth):
+    def test_manual_queue_no_one_accepted(self):
+        """Test that no one gets accepted for a manual picking event."""
+        event = self.new_object('events', spots=100,
+                                selection_strategy='manual')
+
+        user = self.new_object('users')
+
+        self.api.post('/eventsignups', data={
+            'user': str(user['_id']),
+            'event': str(event['_id'])
+        }, status_code=201)
+
+        waiting = self.api.get('/eventsignups?where={"accepted":false}',
+                               status_code=200).json['_items']
+        self.assertEqual(len(waiting), 1)
+
+    def test_fcfs_users_get_auto_accepted(self):
+        """Test that with fcfs the users get automatically accepted on signup
+        and also when a space becomes available"""
+        event = self.new_object('events', spots=1,
+                                selection_strategy='fcfs')
+
+        user = self.new_object('users')
+        user2 = self.new_object('users')
+
+        self.api.post('/eventsignups', data={
+            'user': str(user['_id']),
+            'event': str(event['_id'])
+        }, status_code=201)
+
+        self.api.post('/eventsignups', data={
+            'user': str(user2['_id']),
+            'event': str(event['_id'])
+        }, status_code=201)
+
+        print(self.api.get('/eventsignups').json)
+
+        accepted = self.api.get('/eventsignups?where={"accepted":true}',
+                                status_code=200).json['_items']
+        self.assertEqual(len(accepted), 1)
+
+        # delete the accepted signup
+        self.api.delete('/eventsignups/%s' % accepted[0]['_id'],
+                        headers={'If-Match': accepted[0]['_etag']},
+                        status_code=204)
+
+        # Check that the other guy got accepted
+        waiting = self.api.get('/eventsignups?where={"accepted":false}',
+                               status_code=200).json['_items']
+        self.assertEqual(len(waiting), 0)

--- a/amivapi/tests/events/test_validators.py
+++ b/amivapi/tests/events/test_validators.py
@@ -3,106 +3,51 @@
 # license: AGPLv3, see LICENSE for details. In addition we strongly encourage
 #          you to buy us beer if we meet and you like the software.
 
-"""Test event validators."""
+"""Test general purpose validators of event module."""
 
-from pytz import utc
 import json
-from datetime import datetime, timedelta
 
 from amivapi.tests.utils import WebTestNoAuth
 
 
 class EventValidatorTest(WebTestNoAuth):
-    """Test Class for event validation."""
+    """Unit test class for general purpose validators of event module."""
 
-    def event_data(self, data):
-        """Add minimum needed data for an event (descriptions)."""
-        return dict(title_en='party',
-                    description_en='fun',
-                    catchphrase_en='disco, disco, party, party',
-                    time_advertising_start='1970-01-01T00:00:01Z',
-                    time_advertising_end='2020-01-01T00:00:00Z',
-                    priority=5,
-                    **data)
+    def test_validate_cerberus_schema(self):
+        """ Test cerberus schema validator """
+        self.app.register_resource('test', {
+            'schema': {
+                'field': {
+                    'type': 'cerberus_schema'
+                }
+            }
+        })
 
-    def test_signup_to_event_without_signup(self):
-        """Test that signups to events without a signup are rejected."""
-        ev = self.new_object("events", spots=None)
-        user = self.new_object("users")
-
-        self.api.post("/eventsignups", data={
-            'event': str(ev['_id']),
-            'user': str(user['_id'])
-        }, status_code=422)
-
-    def test_signup_out_of_registration_window(self):
-        """Test that signups out of the registration window are rejected."""
-        t_open = datetime.now(utc) - timedelta(days=2)
-        t_close = datetime.now(utc) - timedelta(days=1)
-
-        ev = self.new_object("events", spots=100,
-                             time_register_start=t_open,
-                             time_register_end=t_close)
-        user = self.new_object("users")
-
-        self.api.post("/eventsignups", data={
-            'event': str(ev['_id']),
-            'user': str(user['_id'])
-        }, status_code=422)
-
-    def test_additional_fields_must_match(self):
-        """Test the validation of additional fields."""
-        ev = self.new_object("events", spots=100,
-                             additional_fields=json.dumps({
-                                 'field1': {
-                                     'type': 'string',
-                                     'maxlength': 10
-                                 },
-                                 'field2': {
-                                     'type': 'integer'
-                                 }
-                             }))
-
-        user = self.new_object("users")
-
-        self.api.post("/eventsignups", data={
-            'user': str(user['_id']),
-            'event': str(ev['_id']),
-            'additional_fields': json.dumps({
-                'field1': 'aaaaaaaaaaaaaaaaaaaaa',
-                'field2': 0
+        self.api.post('/test', data={
+            'field': json.dumps({
+                "random": "json",
+                "things": {
+                    "a": "b"
+                }
             })
         }, status_code=422)
 
-        self.api.post("/eventsignups", data={
-            'user': str(user['_id']),
-            'event': str(ev['_id']),
-            'additional_fields': json.dumps({
-                'field1': 'asdasdasd',
-                'field2': 50
+        self.api.post('/test', data={
+            "field": json.dumps({
+                "field1": {
+                    "type": "integer",
+                    "max": 10
+                },
+                "field2": {
+                    "type": "datetime",
+                    "required": True
+                }
             })
-        }, status_code=201)
-
-    def test_email_signup_only_when_allowed(self):
-        """Test that email signup is only possible if enabled."""
-        ev = self.new_object("events", spots=100, allow_email_signup=False)
-        self.api.post("/eventsignups", data={
-            'email': 'bla@bla.org',
-            'event': str(ev['_id'])
-        }, status_code=422)
-
-        ev = self.new_object("events", spots=100, allow_email_signup=True)
-        self.api.post("/eventsignups", data={
-            'email': 'bla@bla.org',
-            'event': str(ev['_id'])
         }, status_code=201)
 
     def test_depends_any(self):
-        """Test that events need at least one language.
-
-        This tests the depends_any validator.
-        """
-        self.app.register_resource('test_res', {
+        """ This tests the depends_any validator. """
+        self.app.register_resource('test', {
             'resource_methods': ['POST', 'GET'],
             'item_methods': ['GET'],
             'schema': {
@@ -119,119 +64,155 @@ class EventValidatorTest(WebTestNoAuth):
             }
         })
 
-        self.api.post("/test_res", data={'needs_an_option': 1}, status_code=422)
+        self.api.post("/test", data={'needs_an_option': 1}, status_code=422)
 
-        self.api.post("/test_res", data={
+        self.api.post("/test", data={
             'needs_an_option': 1,
             'option1': 1
         }, status_code=201)
 
-        self.api.post("/test_res", data={
+        self.api.post("/test", data={
             'needs_an_option': 1,
             'option2': 1
         }, status_code=201)
 
     def test_later_than(self):
-        """Test the later_than validator.
+        """Test the later_than validator."""
+        self.app.register_resource('test', {
+            'schema': {
+                'field1': {
+                    'type': 'datetime'
+                },
+                'field2': {
+                    'type': 'datetime',
+                    'later_than': 'field1'
+                }
+            }
+        })
 
-        We do this using the start and end date of an event.
-        """
-        self.api.post("/events", data=self.event_data({
-            'time_start': '2016-10-17T21:11:14Z',
-            'time_end': '2016-03-19T13:33:37Z'
-        }), status_code=422)
+        self.api.post("/test", data={
+            'field1': '2016-10-17T21:11:14Z',
+            'field2': '2016-03-19T13:33:37Z'
+        }, status_code=422)
 
-        self.api.post("/events", data=self.event_data({
-            'time_start': '2016-10-17T21:11:14Z',
-            'time_end': '2017-03-19T13:33:37Z'
-        }), status_code=201)
+        self.api.post("/test", data={
+            'field1': '2016-10-17T21:11:14Z',
+            'field2': '2017-03-19T13:33:37Z'
+        }, status_code=201)
 
-    def test_patch_later_than(self):
+    def test_earlier_than(self):
+        """Test the earlier_than validator."""
+        self.app.register_resource('test', {
+            'schema': {
+                'field1': {
+                    'type': 'datetime',
+                    'earlier_than': 'field2'
+                },
+                'field2': {
+                    'type': 'datetime',
+                }
+            }
+        })
+
+        self.api.post("/test", data={
+            'field1': '2016-10-17T21:11:14Z',
+            'field2': '2016-03-19T13:33:37Z'
+        }, status_code=422)
+
+        self.api.post("/test", data={
+            'field1': '2016-10-17T21:11:14Z',
+            'field2': '2017-03-19T13:33:37Z'
+        }, status_code=201)
+
+    def test_patch_time_dependencies(self):
         """Test patching time dependent fields."""
-        ev = self.new_object("events",
-                             spots=1337,
-                             time_start='2016-10-10T13:33:37Z',
-                             time_end='2016-10-20T13:33:37Z')
+        self.app.register_resource('test', {
+            'schema': {
+                'time1': {
+                    'type': 'datetime',
+                    'earlier_than': 'time2'
+                },
+                'time2': {
+                    'type': 'datetime',
+                    'later_than': 'time1'
+                }
+            }
+        })
 
-        headers = {'If-Match': ev['_etag']}
-        url = "/events/%s" % ev['_id']
+        obj = self.new_object("test",
+                              time1='2016-10-10T13:33:37Z',
+                              time2='2016-10-20T13:33:37Z')
 
-        bad_start = {'time_start': '2016-10-25T13:33:37Z'}
-        good_start = {'time_start': '2016-10-15T13:33:37Z'}
+        headers = {'If-Match': obj['_etag']}
+        url = "/test/%s" % obj['_id']
 
-        bad_end = {'time_end': '2016-10-5T13:33:37Z'}
-        good_end = {'time_end': '2016-10-26T13:33:37Z'}
+        bad_time1 = {'time1': '2016-10-25T13:33:37Z'}
+        good_time1 = {'time1': '2016-10-15T13:33:37Z'}
 
-        for bad in bad_start, bad_end:
+        bad_time2 = {'time2': '2016-10-5T13:33:37Z'}
+        good_time2 = {'time2': '2016-10-26T13:33:37Z'}
+
+        for bad in bad_time1, bad_time2:
             self.api.patch(url, headers=headers, data=bad, status_code=422)
 
-        for good in good_start, good_end:
+        for good in good_time1, good_time2:
             r = self.api.patch(url, headers=headers,
                                data=good, status_code=200).json
             # Update etag for next request
             headers['If-Match'] = r['_etag']
 
-    def test_spot_dependencies(self):
-        """Test that the requires if not null validator works.
+    def test_only_if_not_null(self):
+        """Test that the only_if_not_null validator works."""
+        self.app.register_resource('test', {
+            'schema': {
+                'field1': {
+                    'type': 'integer',
+                },
+                'field2': {
+                    'type': 'integer',
+                    'only_if_not_null': 'field1'
+                }
+            }
+        })
 
-        We do this by trying to add an event with spots >= 0, but no
-        further required data.
-        """
-        self.api.post('/events', data=self.event_data({
-            'spots': 100
-        }), status_code=422)
+        self.api.post('/test', data={}, status_code=201)
 
-        self.api.post('/events', data=self.event_data({
-            'spots': 100,
-            'time_register_end': '2016-10-17T21:11:15Z',
-            'allow_email_signup': True
-        }), status_code=422)
+        self.api.post('/test', data={
+            'field1': 1
+        }, status_code=201)
 
-        self.api.post('/events', data=self.event_data({
-            'spots': 100,
-            'time_register_start': '2016-10-17T21:11:14Z',
-            'allow_email_signup': True
-        }), status_code=422)
+        self.api.post('/test', data={
+            'field2': 1
+        }, status_code=422)
 
-        self.api.post('/events', data=self.event_data({
-            'spots': 100,
-            'time_register_start': '2016-10-17T21:11:14Z',
-            'time_register_end': '2016-10-17T21:11:15Z',
-            'allow_email_signup': True
-        }), status_code=201)
+        self.api.post('/test', data={
+            'field1': 1,
+            'field2': 1,
+        }, status_code=201)
 
-    def test_spots_none(self):
-        """Test you can set spots to None and this does not require deps."""
-        self.api.post('/events', data=self.event_data({
-            'spots': None,
-        }), status_code=201)
-
-    def test_fields_depending_on_signup_not_null(self):
-        """Test that signup needs to be not None for fields depending on it."""
-        test_data = [
-            {'allow_email_signup': True},
-            {'additional_fields': ''},
-            {'time_register_start': '2016-10-17T21:11:14Z'},
-        ]
-        # No need to test time end, this depends on time start anyway.
-
-        for data in test_data:
-            data = self.event_data(data)
-
-            data['spots'] = None
-            self.api.post('/events', data=data, status_code=422)
-
-    def test_can_add_time_start(self):
+    def test_can_add_time_for_later_than(self):
         """ Test issue #141
-        The validator of time_start (later_than) assumed, that the field is
+        The validator later_than assumed, that the field is
         already existing on PATCH requests. Check that this is fixed.
         """
-        ev = self.new_object("events", spots=100, allow_email_signup=False)
+        self.app.register_resource('test', {
+            'schema': {
+                'time1': {
+                    'type': 'datetime'
+                },
+                'time2': {
+                    'type': 'datetime',
+                    'later_than': 'time1'
+                }
+            }
+        })
+
+        obj = self.new_object("test")
 
         data = {
-            'time_start': "2016-01-01T00:00:00Z",
-            'time_end': "2016-02-02T00:00:00Z"
+            'time1': "2016-01-01T00:00:00Z",
+            'time2': "2016-02-02T00:00:00Z"
         }
-        ev = self.api.patch('/events/%s' % ev['_id'], data=data,
-                            headers={'If-Match': ev['_etag']},
-                            status_code=200).json
+        self.api.patch('/test/%s' % obj['_id'], data=data,
+                       headers={'If-Match': obj['_etag']},
+                       status_code=200)

--- a/amivapi/tests/events/test_validators.py
+++ b/amivapi/tests/events/test_validators.py
@@ -91,6 +91,10 @@ class EventValidatorTest(WebTestNoAuth):
         })
 
         self.api.post("/test", data={
+            'field2': '2016-10-17T10:10:10Z'
+        }, status_code=201)
+
+        self.api.post("/test", data={
             'field1': '2016-10-17T21:11:14Z',
             'field2': '2016-03-19T13:33:37Z'
         }, status_code=422)
@@ -113,6 +117,10 @@ class EventValidatorTest(WebTestNoAuth):
                 }
             }
         })
+
+        self.api.post("/test", data={
+            'field1': '2016-10-17T10:10:10Z'
+        }, status_code=201)
 
         self.api.post("/test", data={
             'field1': '2016-10-17T21:11:14Z',
@@ -216,3 +224,23 @@ class EventValidatorTest(WebTestNoAuth):
         self.api.patch('/test/%s' % obj['_id'], data=data,
                        headers={'If-Match': obj['_etag']},
                        status_code=200)
+
+    def test_required_if_not(self):
+        """Test required_if_not validator"""
+        self.app.register_resource('test', {
+            'schema': {
+                'field1': {
+                    'type': 'integer',
+                    'required_if_not': 'field2'
+                },
+                'field2': {
+                    'type': 'integer',
+                    'required_if_not': 'field1'
+                }
+            }
+        })
+
+        self.api.post('/test', data={}, status_code=422)
+        self.api.post('/test', data={'field1': 1}, status_code=201)
+        self.api.post('/test', data={'field2': 1}, status_code=201)
+        self.api.post('/test', data={'field1': 1, 'field2': 2}, status_code=201)

--- a/amivapi/tests/fixtures.py
+++ b/amivapi/tests/fixtures.py
@@ -240,6 +240,9 @@ class FixtureMixin(object):
             obj.setdefault('allow_email_signup',
                            random.choice([True, False]))
 
+            obj.setdefault('selection_strategy',
+                           random.choice(['fcfs', 'manual']))
+
     def preprocess_eventsignups(self, schema, obj, fixture):
         """Find random unique combination of user/event"""
         if 'user' not in obj and 'email' not in obj:

--- a/amivapi/utils.py
+++ b/amivapi/utils.py
@@ -122,8 +122,7 @@ class ValidatorAMIV(Validator):
         # If we are patching the issue is more complicated, some fields might
         # have to be checked but are not part of the document because they will
         # not be patched. We have to load them from the database
-        patch = (request.method == 'PATCH')
-        if patch:
+        if request.method == 'PATCH':
             original = self._original_document
             for key in unique_combination:
                 if key not in self.document.keys():

--- a/amivapi/utils.py
+++ b/amivapi/utils.py
@@ -99,6 +99,12 @@ class ValidatorAMIV(Validator):
             self._error(field, "this field can not be changed with PATCH "
                         "unless you have admin rights.")
 
+    def _validate_admin_only(self, enabled, field, value):
+        """Prohibit anyone except admins from setting this field."""
+        if enabled and not g.resource_admin:
+            self._error(field, "This field can only be set with admin "
+                        "permissions.")
+
     def _validate_unique_combination(self, unique_combination, field, value):
         """Validate that a combination of fields is unique.
 


### PR DESCRIPTION
Restructured the tests, generally tidied up code of event module.
There is now a field `selection_strategy` in events and `accepted` in eventsignups. These are used for different methods to give spots to people. FCFS and manual setting are supported. Also emails are sent, when people are automatically admitted to an event. The emails contain a link to give up the spot and let other people get promoted.