### PR TITLE
Exclude ldap, command line tool and tests from coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+omit =
+     amivapi/ldap.py
+     amivapi/cli.py
+     amivapi/tests/*


### PR DESCRIPTION
ldap and command line tool will probably never get coverage. Enforcing coverage of the test does not make sense at many locations as well.