### PR TITLE
use jsonschema in additonal_fields of events

### DIFF
--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -169,12 +169,12 @@ eventdomain = {
             },
             'additional_fields': {
                 'nullable': True,
-                'type': 'json_schema',
+                'type': 'json_schema_object',
                 'only_if_not_null': 'spots',
                 'description': 'must be provided in form of a JSON-Schema. You'
                 'can add here fields you want to know from people signing up '
                 'going further than their email-address.\nThe JSON-Schema will'
-                ' always be overwritten with: {'
+                ' always require these fields: {'
                 '"$schema": "http://json-schema.org/draft-04/schema#",'
                 '"type": "object",'
                 '"additionalProperties": False}'

--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -169,11 +169,15 @@ eventdomain = {
             },
             'additional_fields': {
                 'nullable': True,
-                'type': 'cerberus_schema',
+                'type': 'json_schema',
                 'only_if_not_null': 'spots',
                 'description': 'must be provided in form of a JSON-Schema. You'
                 'can add here fields you want to know from people signing up '
-                'going further than their email-address'
+                'going further than their email-address.\nThe JSON-Schema will'
+                ' always be overwritten with: {'
+                '"$schema": "http://json-schema.org/draft-04/schema#",'
+                '"type": "object",'
+                '"additionalProperties": False}'
             },
             'allow_email_signup': {
                 'nullable': False,

--- a/amivapi/events/validation.py
+++ b/amivapi/events/validation.py
@@ -238,7 +238,7 @@ class EventValidator(object):
             self._original_document is not None and
             self._original_document.get(only_if_not_null) is not None)
 
-        if not(doc.get(only_if_not_null) is not None or exists_in_original):
+        if doc.get(only_if_not_null) is None and not exists_in_original:
             self._error(field, "May only be specified if %s is not null"
                         % only_if_not_null)
 

--- a/amivapi/events/validation.py
+++ b/amivapi/events/validation.py
@@ -236,7 +236,12 @@ class EventValidator(object):
             field (string): name of the validated field
             value: Value of the validated field
         """
-        if self.document.get(only_if_not_null) is None:
+        doc = self.document
+        if self._original_document is not None:
+            # This is a patch. The patch-document will not contain all
+            # information
+            doc = self._original_document
+        if doc.get(only_if_not_null) is None:
             self._error(field, "May only be specified if %s is not null"
                         % only_if_not_null)
 

--- a/amivapi/events/validation.py
+++ b/amivapi/events/validation.py
@@ -8,7 +8,6 @@
 import json
 import pytz
 from datetime import datetime
-from copy import deepcopy
 
 from flask import g, current_app, request
 
@@ -17,7 +16,6 @@ from jsonschema import SchemaError, Draft4Validator
 
 class EventValidator(object):
     """Custom Validator for event validation rules."""
-
 
     def _validate_type_json_event_field(self, field, value):
         """Validate data in json format with event data.

--- a/amivapi/events/validation.py
+++ b/amivapi/events/validation.py
@@ -8,6 +8,7 @@
 import json
 import pytz
 from datetime import datetime
+from copy import deepcopy
 
 from flask import g, current_app, request
 
@@ -238,7 +239,8 @@ class EventValidator(object):
         if self._original_document is not None:
             # This is a patch. The patch-document will not contain all
             # information
-            doc = self._original_document
+            doc = deepcopy(self._original_document)
+            doc.update(self.document)
         if doc.get(only_if_not_null) is None:
             self._error(field, "May only be specified if %s is not null"
                         % only_if_not_null)

--- a/amivapi/events/validation.py
+++ b/amivapi/events/validation.py
@@ -8,7 +8,6 @@
 import json
 import pytz
 from datetime import datetime
-from copy import deepcopy
 
 from flask import g, current_app, request
 
@@ -187,8 +186,7 @@ class EventValidator(object):
     # the timezone is included, sometimes it isn't.
 
     def _get_time(self, fieldname):
-        """Retrieve time field from document or _original_document.
-        """
+        """Retrieve time field from document or _original_document."""
         # Try to pick the value from document first, fall back to original
         time = self.document.get(fieldname)
         if time is None:
@@ -236,17 +234,16 @@ class EventValidator(object):
             value: Value of the validated field
         """
         doc = self.document
-        if self._original_document is not None:
-            # This is a patch. The patch-document will not contain all
-            # information
-            doc = deepcopy(self._original_document)
-            doc.update(self.document)
-        if doc.get(only_if_not_null) is None:
+        exists_in_original = (  # Check original document in case of patches
+            self._original_document is not None and
+            self._original_document.get(only_if_not_null) is not None)
+
+        if not(doc.get(only_if_not_null) is not None or exists_in_original):
             self._error(field, "May only be specified if %s is not null"
                         % only_if_not_null)
 
     def _validate_required_if_not(self, *args):
-        """Dummy function for Cerberus (It complains if it can find the rule).
+        """Dummy function for Cerberus.(It complains if it can find the rule).
 
         Functionality is implemented in the requierd field validation.
         """

--- a/amivapi/events/validation.py
+++ b/amivapi/events/validation.py
@@ -159,14 +159,14 @@ class EventValidator(object):
                         % str(e))
         else:
             # validate if these fields are included exactly as given
-            # (we e.g. always require objects so UI can rely on this)
-            additional_fields_schema = {
+            # (we, e.g., always require objects so UI can rely on this)
+            enforced_fields = {
                 '$schema': 'http://json-schema.org/draft-04/schema#',
                 'type': 'object',
                 'additionalProperties': False
             }
 
-            for key, value in additional_fields_schema.items():
+            for key, value in enforced_fields.items():
                 if key not in json_data or json_data[key] != value:
                     self._error(field,
                                 "'{key}' is required to be set to '{value}'"
@@ -175,7 +175,7 @@ class EventValidator(object):
             try:
                 # now check if it is entirely valid jsonschema
                 v = Draft4Validator(json_data)
-                # by defualt, jsonschema specification allows unknown properties
+                # by default, jsonschema specification allows unknown properties
                 # We do not allow these.
                 v.META_SCHEMA['additionalProperties'] = False
                 v.check_schema(json_data)

--- a/amivapi/events/validation.py
+++ b/amivapi/events/validation.py
@@ -112,7 +112,7 @@ class EventValidator(object):
                                                      None)
 
     def _validate_email_signup_must_be_allowed(self, enabled, field, value):
-        """Validation for a event field in eventsignups.
+        """Validation for an event field in eventsignups.
 
         Validates if the event allows self enrollment.
 

--- a/amivapi/tests/events/test_auth.py
+++ b/amivapi/tests/events/test_auth.py
@@ -70,10 +70,14 @@ class EventAuthTest(WebTest):
         only by admins."""
         event = self.new_object('events',
                                 spots=100,
-                                additional_fields=json.dumps({'a': {}}))
+                                additional_fields=json.dumps({'properties': {
+                                                                 'a': {}
+                                                             }}))
         event2 = self.new_object('events',
                                  spots=100,
-                                 additional_fields=json.dumps({'a': {}}))
+                                 additional_fields=json.dumps({'properties': {
+                                                                 'a': {}
+                                                             }}))
         user = self.new_object('users')
         user2 = self.new_object('users')
         user_token = self.get_user_token(user['_id'])
@@ -82,7 +86,7 @@ class EventAuthTest(WebTest):
         signup = self.api.post('/eventsignups', data={
             'user': str(user['_id']),
             'event': str(event['_id']),
-            'additional_fields': '{"a":1}'
+            'additional_fields': '{"a": 1}'
         }, token=root_token, status_code=201).json
 
         # Check that user can not be patched

--- a/amivapi/tests/events/test_auth.py
+++ b/amivapi/tests/events/test_auth.py
@@ -68,14 +68,14 @@ class EventAuthTest(WebTest):
     def test_signups_patchable_fields(self):
         """Test that only additional_fields can be changes by users and accepted
         only by admins."""
-        event = self.new_object('events', spots=100,
-            additional_fields=json.dumps({
+        event = self.new_object(
+            'events', spots=100, additional_fields=json.dumps({
                 "$schema": "http://json-schema.org/draft-04/schema#",
                 "type": "object",
                 "additionalProperties": False,
                 'properties': {'a': {}}}))
-        event2 = self.new_object('events', spots=100,
-            additional_fields=json.dumps({
+        event2 = self.new_object(
+            'events', spots=100, additional_fields=json.dumps({
                 "$schema": "http://json-schema.org/draft-04/schema#",
                 "type": "object",
                 "additionalProperties": False,

--- a/amivapi/tests/events/test_auth.py
+++ b/amivapi/tests/events/test_auth.py
@@ -68,16 +68,19 @@ class EventAuthTest(WebTest):
     def test_signups_patchable_fields(self):
         """Test that only additional_fields can be changes by users and accepted
         only by admins."""
-        event = self.new_object('events',
-                                spots=100,
-                                additional_fields=json.dumps({'properties': {
-                                                                 'a': {}
-                                                             }}))
-        event2 = self.new_object('events',
-                                 spots=100,
-                                 additional_fields=json.dumps({'properties': {
-                                                                 'a': {}
-                                                             }}))
+        event = self.new_object('events', spots=100,
+            additional_fields=json.dumps({
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
+                "additionalProperties": False,
+                'properties': {'a': {}}}))
+        event2 = self.new_object('events', spots=100,
+            additional_fields=json.dumps({
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
+                "additionalProperties": False,
+                'properties': {'a': {}}}))
+
         user = self.new_object('users')
         user2 = self.new_object('users')
         user_token = self.get_user_token(user['_id'])

--- a/amivapi/tests/events/test_model.py
+++ b/amivapi/tests/events/test_model.py
@@ -37,13 +37,15 @@ class EventModelTest(WebTestNoAuth):
         """Test the validation of additional fields."""
         ev = self.new_object("events", spots=100,
                              additional_fields=json.dumps({
-                                 'field1': {
-                                     'type': 'string',
-                                     'maxlength': 10
-                                 },
-                                 'field2': {
-                                     'type': 'integer'
-                                 }
+                                 'properties': {
+                                     'field1': {
+                                         'type': 'string',
+                                         'maxLength': 10
+                                     },
+                                     'field2': {
+                                         'type': 'integer'
+                                     }},
+                                 'required': ['field1']
                              }))
 
         user = self.new_object("users")
@@ -59,6 +61,14 @@ class EventModelTest(WebTestNoAuth):
             'event': str(ev['_id']),
             'additional_fields': json.dumps({
                 'field1': 'aaaaaaaaaaaaaaaaaaaaa',
+                'field2': 0
+            })
+        }, status_code=422)
+
+        self.api.post("/eventsignups", data={
+            'user': str(user['_id']),
+            'event': str(ev['_id']),
+            'additional_fields': json.dumps({
                 'field2': 0
             })
         }, status_code=422)

--- a/amivapi/tests/events/test_model.py
+++ b/amivapi/tests/events/test_model.py
@@ -61,7 +61,7 @@ class EventModelTest(WebTestNoAuth):
                 "type": "object",
                 "additionalProperties": False
             })
-        }, status_code=201)
+        }, status_code=200)
 
 
     def test_additional_fields_must_match(self):

--- a/amivapi/tests/events/test_model.py
+++ b/amivapi/tests/events/test_model.py
@@ -40,14 +40,14 @@ class EventModelTest(WebTestNoAuth):
 
         event_url = '/events/{id}'.format(id=ev['_id'])
 
-        self.api.patch(event_url, headers={'If-Match': ev['_etag']}, data= {
+        self.api.patch(event_url, headers={'If-Match': ev['_etag']}, data={
             'additional_fields': json.dumps({
                 "$schema": "http://json-schema.org/draft-04/schema#",
                 "type": "object"
             })
         }, status_code=422)
 
-        self.api.patch(event_url, headers={'If-Match': ev['_etag']}, data= {
+        self.api.patch(event_url, headers={'If-Match': ev['_etag']}, data={
             'additional_fields': json.dumps({
                 "$schema": "http://json-schema.org/draft-04/schema#",
                 "type": "object",
@@ -55,14 +55,13 @@ class EventModelTest(WebTestNoAuth):
             })
         }, status_code=422)
 
-        self.api.patch(event_url, headers={'If-Match': ev['_etag']}, data= {
+        self.api.patch(event_url, headers={'If-Match': ev['_etag']}, data={
             'additional_fields': json.dumps({
                 "$schema": "http://json-schema.org/draft-04/schema#",
                 "type": "object",
                 "additionalProperties": False
             })
         }, status_code=200)
-
 
     def test_additional_fields_must_match(self):
         """Test the validation of additional fields."""

--- a/amivapi/tests/events/test_validators.py
+++ b/amivapi/tests/events/test_validators.py
@@ -13,12 +13,12 @@ from amivapi.tests.utils import WebTestNoAuth
 class EventValidatorTest(WebTestNoAuth):
     """Unit test class for general purpose validators of event module."""
 
-    def test_validate_cerberus_schema(self):
+    def test_validate_json_schema(self):
         """ Test cerberus schema validator """
         self.app.register_resource('test', {
             'schema': {
                 'field': {
-                    'type': 'cerberus_schema'
+                    'type': 'json_schema'
                 }
             }
         })
@@ -34,14 +34,15 @@ class EventValidatorTest(WebTestNoAuth):
 
         self.api.post('/test', data={
             "field": json.dumps({
-                "field1": {
-                    "type": "integer",
-                    "max": 10
-                },
-                "field2": {
-                    "type": "datetime",
-                    "required": True
-                }
+                'properties': {
+                    "field1": {
+                        "type": "integer",
+                        "maximum": 10
+                    },
+                    "field2": {
+                        "type": "string"
+                    }},
+                "required": ["field2"]
             })
         }, status_code=201)
 

--- a/amivapi/tests/events/test_validators.py
+++ b/amivapi/tests/events/test_validators.py
@@ -13,12 +13,12 @@ from amivapi.tests.utils import WebTestNoAuth
 class EventValidatorTest(WebTestNoAuth):
     """Unit test class for general purpose validators of event module."""
 
-    def test_validate_json_schema(self):
+    def test_validate_json_schema_object(self):
         """ Test cerberus schema validator """
         self.app.register_resource('test', {
             'schema': {
                 'field': {
-                    'type': 'json_schema'
+                    'type': 'json_schema_object'
                 }
             }
         })
@@ -34,6 +34,9 @@ class EventValidatorTest(WebTestNoAuth):
 
         self.api.post('/test', data={
             "field": json.dumps({
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
+                "additionalProperties": False,
                 'properties': {
                     "field1": {
                         "type": "integer",


### PR DESCRIPTION
This PR fixes #158 and #91, aswell as a minor bug in some event-validator.

*Debatable*: json-schema are more complex than cerberus-schema. I now require the user to specify a full json-schema for additional_fields, while ensuring in the validator that the following fields are always set accordingly:

    {
           "$schema": "http://json-schema.org/draft-04/schema#",
           "type": "object",
           "additionalProperties": False
    }

This is necessary to ensure that additional_fields specifies a dict and not a list (which makes it easier for an UI to create an understandable, dynamic form for these fields), aswell as to ensure the correct usage of json-schema to our purposes. One could also overwrite this api-side, but it would be instransparent to let somebody submit a non-complete json-schema and add or overwrite values. 