### PR TITLE
Apikeys as resource

### DIFF
--- a/amivapi/auth/apikeys.py
+++ b/amivapi/auth/apikeys.py
@@ -3,38 +3,107 @@
 # license: AGPLv3, see LICENSE for details. In addition we strongly encourage
 #          you to buy us beer if we meet and you like the software.
 
-"""Hook to allow authorization with apikeys."""
+"""Authorization with apikeys.
+
+Provides the apikey resource and hooks to handle authorization with a key.
+
+API keys should only be created or modified by admins.
+"""
+from os import urandom
+from base64 import b64encode
+from datetime import datetime as dt
 
 from flask import abort, current_app, g
 
-from ruamel import yaml
+from amivapi.utils import register_domain
+
+from .auth import AmivTokenAuth
 
 
 def authorize_apikeys(resource):
-    """Check if user is an apikey, and if it is, do authorization."""
-    permissions = [
-        data['permissions'] for data in current_app.config['APIKEYS'].values()
-        if data['token'] == g.get('current_token')]
-    if permissions:
-        # We can just take first (and only) element since token is unique
-        permission = permissions[0].get(resource)
+    """Check if user is an apikey, and if it is, do authorization.
+
+    Also update 'updated' timestamp everytime a key is accessed
+    """
+    apikeys = current_app.data.driver.db['apikeys']
+    apikey = apikeys.find_one({'token': g.get('current_token')},
+                              {'permissions': 1})
+
+    if apikey:
+        # Get permission for resource if they exist
+        permission = apikey['permissions'].get(resource)
+
+        # Update timestamp (remove microseconds to match mongo precision)
+        new_time = dt.utcnow().replace(microsecond=0)
+        apikeys.update_one({'_id': apikey['_id']},
+                           {'$set': {'_updated': new_time}})
 
         if permission == 'read':
             g.resource_admin_readonly = True
         elif permission == 'readwrite':
             g.resource_admin = True
         elif g.get('auth_required'):
-            abort(403, "The APIKEY does not grant the required permissions.")
+            abort(403, "The API key exists but does not grant the required "
+                       "permissions.")
+
+
+class ApikeyAuth(AmivTokenAuth):
+    """Do not let (non-admin) users view API keys at all.
+
+    We don't want to filter the output , we want to abort completely."""
+    def create_user_lookup_filter(self, user):
+        abort(403)
+
+
+apikeydomain = {
+    'apikeys': {
+        'description': "API Keys can be used to given permissions to other "
+                       "applications.",
+
+        'public_methods': [],
+        'public_item_methods': [],
+        'resource_methods': ['GET', 'POST'],
+        'item_methods': ['GET', 'PATCH', 'DELETE'],
+
+        'authentication': ApikeyAuth,
+
+        'schema': {
+            'name': {
+                'type': 'string',
+                'required': True,
+                'nullable': False,
+                'empty': False,
+                'description': 'A name to identify the key.',
+                'unique': True
+                },
+            'token': {
+                'type': 'string',
+                'readonly': True,
+                'description': 'The token that can be used for auth. '
+                'Will be randomly generated for every new key.'
+            },
+            'permissions': {
+                'type': 'dict',
+                'propertyschema': {'type': 'string',
+                                   'api_resources': True},
+                'valueschema': {'type': 'string',
+                                'allowed': ['read', 'readwrite']},
+                'description': 'Permissions the apikey grants. '
+                'Key, value pairs with resource names as keys and either '
+                '"read" or "readwrite"'
+            }
+        },
+    }
+}
+
+
+def generate_tokens(items):
+    for item in items:
+        item['token'] = b64encode(urandom(256)).decode('utf_8')
 
 
 def init_apikeys(app):
-    """Load apikeys from config file and add auth hook."""
-    try:
-        with open(app.config['APIKEY_FILENAME'], 'r') as f:
-            data = yaml.load(f)
-            app.config['APIKEYS'] = data if data is not None else {}
-    except IOError:
-        app.config['APIKEYS'] = {}
-
-    # Add auth hook
+    """Register API Key resource and add auth hook."""
+    register_domain(app, apikeydomain)
     app.after_auth += authorize_apikeys
+    app.on_insert_apikeys += generate_tokens

--- a/amivapi/auth/apikeys.py
+++ b/amivapi/auth/apikeys.py
@@ -50,7 +50,9 @@ def authorize_apikeys(resource):
 class ApikeyAuth(AmivTokenAuth):
     """Do not let (non-admin) users view API keys at all.
 
-    We don't want to filter the output , we want to abort completely."""
+    If this hook gets called, the user is not an admin for this resource.
+    Therefore no results should be given. To give a more precise error message,
+    we abort. Otherwise normal users would just see an empty list."""
     def create_user_lookup_filter(self, user):
         abort(403)
 

--- a/amivapi/groups/validation.py
+++ b/amivapi/groups/validation.py
@@ -49,11 +49,6 @@ class GroupValidator(object):
                             "Group with id '%s' does not allow self enrollment"
                             " and you are not the group moderator.")
 
-    def _validate_api_resources(self, enabled, field, value):
-        """Value must be in api domain."""
-        if enabled and value not in current_app.config['DOMAIN']:
-            self._error(field, "'%s' is not a api resource." % value)
-
     def _validate_unique_elements(self, enabled, field, value):
         """Validate that a list does only contain unique elements."""
         if enabled:

--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -45,7 +45,6 @@ MEDIA_URL = 'string'  # Very important to match url properly
 EXTENDED_MEDIA_INFO = ['name', 'content_type', 'length', 'upload_date']
 
 DEFAULT_CONFIG_FILENAME = 'config.yaml'
-APIKEY_FILENAME = 'apikeys.yaml'
 
 PASSWORD_CONTEXT = CryptContext(
     schemes=["pbkdf2_sha256"],

--- a/amivapi/tests/auth/test_apikeys.py
+++ b/amivapi/tests/auth/test_apikeys.py
@@ -87,7 +87,7 @@ class ApiKeyPermissionsTest(WebTest):
         self.api.post('/apikeys', data={}, token=token, status_code=403)
 
     def test_readwrite_permission(self):
-        """Read permission allows everything."""
+        """Readwrite permission allows everything."""
         key = self.new_object("apikeys", permissions={'apikeys': 'readwrite'})
         token = key['token']
         item_url = '/apikeys/%s' % key['_id']

--- a/amivapi/tests/auth/test_apikeys.py
+++ b/amivapi/tests/auth/test_apikeys.py
@@ -4,65 +4,130 @@
 #          you to buy us beer if we meet and you like the software.
 """Test apikey authorization."""
 
-from amivapi.tests.utils import WebTest
-import os
-from ruamel import yaml
-import tempfile
+from amivapi.tests.utils import WebTest, WebTestNoAuth
 
 
-class ApiKeyTest(WebTest):
-    """Apikey auth test class."""
+class ApiKeyMethodsTest(WebTest):
+    """Apikey auth test class.
 
-    token = 'ABCDEFG'
-    APIKEYS = {
-        'testkey': {
-            'token': token,
-            'permissions': {
-                'sessions': 'read',
-            }
-        }
-    }
+    Since they grant possible all permissions, make extra sure that auth works
+    right.
+    """
+    def _prepare_tokens_and_key(self):
+        user = self.new_object('users')
+        user_token = self.get_user_token(user['_id'])
+        admin_token = self.get_root_token()
+        key = self.new_object('apikeys')
+        return (key, user_token, admin_token)
 
-    def setUp(self):
-        """Create temp apikey file before normal setup."""
-        with tempfile.NamedTemporaryFile(
-                mode='w', suffix='.yaml', delete=False) as f:
-            yaml.safe_dump(self.APIKEYS, f, default_flow_style=False)
-            self.test_config['APIKEY_FILENAME'] = f.name
+    def test_only_admin_can_read_item(self):
+        """GET on item endpoint only for admins."""
+        (key, user_token, admin_token) = self._prepare_tokens_and_key()
+        url = "/apikeys/%s" % key['_id']
 
-        super(ApiKeyTest, self).setUp()
+        self.api.get(url, status_code=401)
+        self.api.get(url, token=user_token, status_code=403)
+        self.api.get(url, token=admin_token, status_code=200)
 
-    def tearDown(self):
-        """Remove key file."""
-        os.remove(self.test_config['APIKEY_FILENAME'])
+    def test_only_admin_can_read_resource(self):
+        """GET on resource only for admins."""
+        (_, user_token, admin_token) = self._prepare_tokens_and_key()
+        url = "/apikeys"
 
-        super(ApiKeyTest, self).tearDown()
+        self.api.get(url, status_code=401)
+        self.api.get(url, token=user_token, status_code=403)
+        self.api.get(url, token=admin_token, status_code=200)
 
-    def test_apikey_gives_permission(self):
-        """Test that APIKEY gives specified permissions."""
-        self.load_fixture({
-            'users': [{}, {}],
-            'sessions': [{}, {}]
-        })
+    def test_only_admin_can_create(self):
+        """POST only for admins."""
+        (_, user_token, admin_token) = self._prepare_tokens_and_key()
+        data = {'name': 'super_backdoor_key',
+                'permissions': {'apikeys': 'readwrite'}}
+        url = "/apikeys"
 
-        sessions = self.api.get('/sessions', token=self.token,
-                                status_code=200).json['_items']
+        self.api.post(url, data=data, status_code=401)
+        self.api.post(url, data=data, token=user_token, status_code=403)
+        self.api.post(url, data=data, token=admin_token, status_code=201)
 
-        self.assertEqual(len(sessions), 2)
+    def test_only_admin_can_update(self):
+        """PATCH only for admins."""
+        (key, user_token, admin_token) = self._prepare_tokens_and_key()
+        data = {'name': 2 * key['name']}  # New: Twice the fun!
+        url = "/apikeys/%s" % key['_id']
+        etag = {'If-Match': key['_etag']}
 
-        self.api.delete('/sessions/%s' % sessions[0]['_id'], token=self.token,
-                        headers={'If-Match': sessions[0]['_etag']},
-                        status_code=403)
+        self.api.patch(url, data=data, headers=etag, status_code=401)
+        self.api.patch(url, data=data, headers=etag, token=user_token,
+                       status_code=403)
+        self.api.patch(url, data=data, headers=etag, token=admin_token,
+                       status_code=200)
 
-        self.api.get('/users', token=self.token, status_code=403)
+    def test_only_admin_can_delete(self):
+        """PATCH only for admins."""
+        (key, user_token, admin_token) = self._prepare_tokens_and_key()
+        url = "/apikeys/%s" % key['_id']
+        etag = {'If-Match': key['_etag']}
 
-    def test_readwrite(self):
-        """Test also the readwrite permission."""
-        user = self.load_fixture({'users': [{}]})[0]
+        self.api.delete(url, headers=etag, status_code=401)
+        self.api.delete(url, headers=etag, token=user_token, status_code=403)
+        self.api.delete(url, headers=etag, token=admin_token, status_code=204)
 
-        self.app.config['APIKEYS']['testkey']['permissions']['users'] = \
-            'readwrite'
 
-        self.api.delete('/users/%s' % user['_id'], token=self.token,
-                        headers={'If-Match': user['_etag']},
-                        status_code=204)
+class ApiKeyPermissionsTest(WebTest):
+    """Test that an api key grants permissions."""
+    def test_read_permission(self):
+        """Read permission allows get, but no writing."""
+        key = self.new_object("apikeys", permissions={'apikeys': 'read'})
+        token = key['token']
+        item_url = '/apikeys/%s' % key['_id']
+
+        self.api.get('/apikeys', token=token, status_code=200)
+        self.api.get(item_url, token=token, status_code=200)
+
+        self.api.post('/apikeys', data={}, token=token, status_code=403)
+
+    def test_readwrite_permission(self):
+        """Read permission allows everything."""
+        key = self.new_object("apikeys", permissions={'apikeys': 'readwrite'})
+        token = key['token']
+        item_url = '/apikeys/%s' % key['_id']
+        etag = {'If-Match': key['_etag']}
+
+        self.api.get('/apikeys', token=token, status_code=200)
+        self.api.get(item_url, token=token, status_code=200)
+
+        self.api.delete(item_url, headers=etag, token=token, status_code=204)
+
+    def test_different_resource(self):
+        """Test that apikeys for different resources have no effect."""
+        key = self.new_object("apikeys", permissions={'users': 'readwrite'})
+        token = key['token']
+
+        self.api.get('/apikeys', token=token, status_code=403)
+
+
+class ApiKeyModelTests(WebTestNoAuth):
+    """Test that tokens are correctly generated and permissions validation."""
+    def test_token_generation(self):
+        """Use a batch post to verify all items get distinct keys."""
+        data = [{'name': 'key1', 'permissions': {'apikeys': 'read'}},
+                {'name': 'key2', 'permissions': {'apikeys': 'readwrite'}}]
+
+        result = self.api.post("/apikeys", data=data).json
+        tokens = [item['token'] for item in result['_items']]
+
+        self.assertNotEquals(tokens[0], tokens[1])
+        # Assert keys are not empty
+        for token in tokens:
+            self.assertTrue(len(token) > 0)
+
+    def test_permission_validation(self):
+        wrong_key = {'name': 'k1', 'permissions': {'notAResource': 'read'}}
+        wrong_value = {'name': 'k2', 'permissions': {'apikeys': 'roodwroat'}}
+        read_ok = {'name': 'k3', 'permissions': {'apikeys': 'read'}}
+        readwrite_ok = {'name': 'k4', 'permissions': {'apikeys': 'readwrite'}}
+
+        self.api.post("/apikeys", data=wrong_key, status_code=422)
+        self.api.post("/apikeys", data=wrong_value, status_code=422)
+        self.api.post("/apikeys", data=read_ok, status_code=201)
+        self.api.post("/apikeys", data=readwrite_ok, status_code=201)

--- a/amivapi/tests/test_media.py
+++ b/amivapi/tests/test_media.py
@@ -100,7 +100,7 @@ class MediaTest(WebTestNoAuth):
         """Test that file not found is suppressed and nothing else."""
         with ignore_not_found():
             # This will raise file not found, nothing should happen
-            open("", 'r')
+            open("")
 
         # Is raised for any other OSError or IOError
         for exc in (OSError, IOError):

--- a/amivapi/utils.py
+++ b/amivapi/utils.py
@@ -72,6 +72,11 @@ def mail(sender, to, subject, text):
 class ValidatorAMIV(Validator):
     """Validator subclass adding more validation for special fields."""
 
+    def _validate_api_resources(self, enabled, field, value):
+        """Value must be in api domain."""
+        if enabled and value not in app.config['DOMAIN']:
+            self._error(field, "'%s' is not a api resource." % value)
+
     def _validate_not_patchable(self, enabled, field, value):
         """Custom Validator to inhibit patching of the field.
 


### PR DESCRIPTION
I was starting to write tests for the CLI when I thought: Do API Keys really need to be handled with CLI?

I think they would work better as an API resource.

Benefits:
- They could be managed more easily with admintools
- With database backups API keys will also be safed
- We don't need an additional config file for the keys.

Since the functionality provided is the same I can't see any downsides.

Instead of creating an issue I thought I'd go ahead an just implement it. What are your opinions?