### PR TITLE
Fix code to comply with stricter code styleguides

### DIFF
--- a/amivapi/auth/__init__.py
+++ b/amivapi/auth/__init__.py
@@ -4,27 +4,25 @@
 #          you to buy us beer if we meet and you like the software.
 
 """Auth and session endpoint initialization."""
-
-from amivapi.utils import register_domain
-
-from .sessions import sessiondomain, process_login
-from . import apikeys
-from .auth import (
+from amivapi.auth import apikeys
+from amivapi.auth.auth import (
+    abort_if_not_public,
+    add_lookup_filter,
     AmivTokenAuth,
     authenticate,
     check_if_admin,
-    abort_if_not_public,
-    add_lookup_filter,
-    check_resource_write_permission,
-    check_item_write_permission
+    check_item_write_permission,
+    check_resource_write_permission
 )
-from .link_methods import (
-    add_permitted_methods_after_update,
-    add_permitted_methods_after_insert,
+from amivapi.auth.link_methods import (
     add_permitted_methods_after_fetch_item,
     add_permitted_methods_after_fetch_resource,
+    add_permitted_methods_after_insert,
+    add_permitted_methods_after_update,
     add_permitted_methods_for_home
 )
+from amivapi.auth.sessions import process_login, sessiondomain
+from amivapi.utils import register_domain
 
 
 def init_app(app):

--- a/amivapi/auth/apikeys.py
+++ b/amivapi/auth/apikeys.py
@@ -9,15 +9,14 @@ Provides the apikey resource and hooks to handle authorization with a key.
 
 API keys should only be created or modified by admins.
 """
-from os import urandom
 from base64 import b64encode
 from datetime import datetime as dt
+from os import urandom
 
 from flask import abort, current_app, g
 
+from amivapi.auth.auth import AmivTokenAuth
 from amivapi.utils import register_domain
-
-from .auth import AmivTokenAuth
 
 
 def authorize_apikeys(resource):
@@ -77,7 +76,7 @@ apikeydomain = {
                 'empty': False,
                 'description': 'A name to identify the key.',
                 'unique': True
-                },
+            },
             'token': {
                 'type': 'string',
                 'readonly': True,

--- a/amivapi/auth/auth.py
+++ b/amivapi/auth/auth.py
@@ -74,8 +74,8 @@ Item endpoints:
 from datetime import datetime as dt
 from functools import wraps
 
-from flask import current_app, g, request, abort
 from eve.auth import BasicAuth, resource_auth
+from flask import abort, current_app, g, request
 
 
 class AmivTokenAuth(BasicAuth):

--- a/amivapi/auth/link_methods.py
+++ b/amivapi/auth/link_methods.py
@@ -10,10 +10,10 @@ Links are only added for resources using AmivTokenAuth.
 
 import json
 
-from flask import current_app, g
 from eve.auth import resource_auth
+from flask import current_app, g
 
-from .auth import AmivTokenAuth, authenticate, check_if_admin
+from amivapi.auth import AmivTokenAuth, authenticate, check_if_admin
 
 
 def _get_item_methods(resource, item):

--- a/amivapi/auth/sessions.py
+++ b/amivapi/auth/sessions.py
@@ -4,20 +4,20 @@
 #          you to buy us beer if we meet and you like the software.
 """Sessions endpoint."""
 
-from os import urandom
 from base64 import b64encode
+import datetime
+from os import urandom
+
 from bson import ObjectId
 from bson.errors import InvalidId
-import datetime
-
-from flask import abort, current_app as app
 from eve.methods.patch import patch_internal
-from eve.utils import debug_error_message, config
+from eve.utils import config, debug_error_message
+from flask import abort, current_app as app
 
+from amivapi.auth import AmivTokenAuth
 from amivapi.cron import periodic
-from amivapi.utils import admin_permissions
 from amivapi.ldap import ldap_connector
-from .auth import AmivTokenAuth
+from amivapi.utils import admin_permissions
 
 
 class SessionAuth(AmivTokenAuth):

--- a/amivapi/beverages/__init__.py
+++ b/amivapi/beverages/__init__.py
@@ -6,10 +6,8 @@
 
 Since there are no hooks or anything everything is just in here.
 """
-
-from amivapi.utils import register_domain
-
 from amivapi.auth import AmivTokenAuth
+from amivapi.utils import register_domain
 
 
 class BeveragesAuth(AmivTokenAuth):

--- a/amivapi/bootstrap.py
+++ b/amivapi/bootstrap.py
@@ -6,24 +6,24 @@
 """API factory."""
 
 from os import getcwd
+
+from eve import Eve
+from flask import Config
 from ruamel import yaml
 
-from flask import Config
-from eve import Eve
-
 from amivapi import (
-    users,
     auth,
-    cron,
-    events,
-    media,
-    groups,
-    utils,
-    joboffers,
     beverages,
     cascade,
+    cron,
+    documentation,
+    events,
+    groups,
+    joboffers,
+    media,
     studydocs,
-    documentation
+    users,
+    utils
 )
 from amivapi.ldap import ldap_connector
 from amivapi.settings import DEFAULT_CONFIG_FILENAME

--- a/amivapi/cascade.py
+++ b/amivapi/cascade.py
@@ -11,10 +11,10 @@ referencing object. If false, the reference will be set to NULL, when the
 referenced object is deleted.
 """
 
-from flask import current_app
-from werkzeug.exceptions import NotFound
 from eve.methods.delete import deleteitem_internal
 from eve.methods.patch import patch_internal
+from flask import current_app
+from werkzeug.exceptions import NotFound
 
 from amivapi.utils import admin_permissions
 

--- a/amivapi/cli.py
+++ b/amivapi/cli.py
@@ -39,9 +39,9 @@ def cron(config):
 
 @cli.command()
 @config_option
-@option('--all', is_flag=True, help="Sync all users.")
+@option('--all', 'sync_all', is_flag=True, help="Sync all users.")
 @argument('nethz', nargs=-1)
-def ldap_sync(config, all, nethz):
+def ldap_sync(config, sync_all, nethz):
     """Synchronize users with eth ldap.
 
     Examples:
@@ -55,7 +55,7 @@ def ldap_sync(config, all, nethz):
         echo("LDAP is not enabled, can't proceed!")
     else:
         with app.test_request_context():
-            if all:
+            if sync_all:
                 res = ldap_connector.sync_all()
                 echo("Synchronized %i users." % len(res))
             else:
@@ -147,8 +147,8 @@ def no_ldap_prompts(ctx, param, value):
         prompt="LDAP password",
         help="LDAP password.")
 # Specify config file (optional)
-@argument("file", type=File('w'), default=DEFAULT_CONFIG_FILENAME)
-def create_config(file, **data):
+@argument("config_file", type=File('w'), default=DEFAULT_CONFIG_FILENAME)
+def create_config(config_file, **data):
     """Generate a config file."""
     # Add secret for token generation
     data['TOKEN_SECRET'] = b64encode(urandom(32)).decode('utf_8')
@@ -159,5 +159,5 @@ def create_config(file, **data):
         del data['LDAP_USER']
         del data['LDAP_PASS']
 
-    file.write("# Automatically generated on %s\n\n" % dt.utcnow())
-    yaml.safe_dump(data, file, default_flow_style=False)
+    config_file.write("# Automatically generated on %s\n\n" % dt.utcnow())
+    yaml.safe_dump(data, config_file, default_flow_style=False)

--- a/amivapi/cli.py
+++ b/amivapi/cli.py
@@ -5,16 +5,17 @@
 
 """A command line interface for AMIVApi."""
 
-from os import urandom
 from base64 import b64encode
 from datetime import datetime as dt
-from click import echo, group, option, argument, Path, File
+from os import urandom
+
+from click import argument, echo, File, group, option, Path
 from ruamel import yaml
 
 from amivapi.bootstrap import create_app
 from amivapi.cron import run_scheduled_tasks
 from amivapi.ldap import ldap_connector
-from amivapi.settings import DEFAULT_CONFIG_FILENAME, STORAGE_DIR, FORWARD_DIR
+from amivapi.settings import DEFAULT_CONFIG_FILENAME, FORWARD_DIR, STORAGE_DIR
 
 
 @group()

--- a/amivapi/cron.py
+++ b/amivapi/cron.py
@@ -117,7 +117,7 @@ def schedule_once_soon(func, *args):
     time. Also check, that it is not already scheduled to be run first.
     """
     if current_app.data.driver.db['scheduled_tasks'].find(
-                    {'function': func_str(func)}).count() != 0:
+            {'function': func_str(func)}).count() != 0:
         return
     schedule_task(datetime.utcnow(), func, *args)
 

--- a/amivapi/documentation.py
+++ b/amivapi/documentation.py
@@ -74,16 +74,17 @@ def init_app(app):
     # just an example of how to include code samples
     add_documentation({'paths': {'/sessions': {'post': {
         'x-code-samples': [
-            {'lang': 'python',
-             'source': '\n\n'.join([
-                'import requests',
-                ('login = requests.post("http://api.amiv.ethz.ch/sessions", '
-                 'data={"user": "myuser", "password": "mypassword"})'),
-                "token = login.json()['token']",
-                ('# now use this token to authenticate a request\n'
-                 'response = requests.get('
-                 '"https://api.amiv.ethz.ch/users/myuser", '
-                 'auth=requests.auth.HTTPBasicAuth(token, ""))')])
-             }
+            {
+                'lang': 'python',
+                'source': '\n\n'.join([
+                    'import requests',
+                    ('login = requests.post("http://api.amiv.ethz.ch/sessions",'
+                     ' data={"user": "myuser", "password": "mypassword"})'),
+                    "token = login.json()['token']",
+                    ('# now use this token to authenticate a request\n'
+                     'response = requests.get('
+                     '"https://api.amiv.ethz.ch/users/myuser", '
+                     'auth=requests.auth.HTTPBasicAuth(token, ""))')])
+            }
         ]
     }}}})

--- a/amivapi/documentation.py
+++ b/amivapi/documentation.py
@@ -5,9 +5,8 @@
 
 """Eve Swagger initialization."""
 
+from eve_swagger import add_documentation, swagger
 from flask import Blueprint, render_template_string
-
-from eve_swagger import swagger, add_documentation
 
 from amivapi.utils import register_validator
 

--- a/amivapi/events/__init__.py
+++ b/amivapi/events/__init__.py
@@ -8,11 +8,17 @@ Contains settings for eve resource, special validation and email_confirmation
 logic needed for signup of non members to events.
 """
 
-from amivapi.utils import register_domain, register_validator
 
-from .model import eventdomain
-from .authorization import EventAuthValidator
-from .projections import (
+from amivapi.events.authorization import EventAuthValidator
+from amivapi.events.emails import (
+    add_confirmed_before_insert,
+    add_confirmed_before_insert_bulk,
+    email_blueprint,
+    send_confirmmail_to_unregistered_users,
+    send_confirmmail_to_unregistered_users_bulk
+)
+from amivapi.events.model import eventdomain
+from amivapi.events.projections import (
     add_email_to_signup,
     add_email_to_signup_collection,
     add_position_to_signup,
@@ -20,21 +26,15 @@ from .projections import (
     add_signup_count_to_event,
     add_signup_count_to_event_collection
 )
-from .validation import EventValidator
-from .emails import (
-    email_blueprint,
-    send_confirmmail_to_unregistered_users,
-    send_confirmmail_to_unregistered_users_bulk,
-    add_confirmed_before_insert,
-    add_confirmed_before_insert_bulk
-)
-from .queue import (
+from amivapi.events.queue import (
     add_accepted_before_insert,
     add_accepted_before_insert_collection,
+    update_waiting_list_after_delete,
     update_waiting_list_after_insert,
-    update_waiting_list_after_insert_collection,
-    update_waiting_list_after_delete
+    update_waiting_list_after_insert_collection
 )
+from amivapi.events.validation import EventValidator
+from amivapi.utils import register_domain, register_validator
 
 
 def init_app(app):

--- a/amivapi/events/emails.py
+++ b/amivapi/events/emails.py
@@ -6,17 +6,14 @@
 
 Needed when external users want to sign up for public events.
 """
-
-from itsdangerous import Signer, BadSignature
 from bson import ObjectId
-
-from flask import current_app, Blueprint, redirect, url_for
-
 from eve.methods.delete import deleteitem_internal
 from eve.methods.patch import patch_internal
+from flask import Blueprint, current_app, redirect, url_for
+from itsdangerous import BadSignature, Signer
 
+from amivapi.events.queue import update_waiting_list
 from amivapi.utils import mail
-from .queue import update_waiting_list
 
 email_blueprint = Blueprint('emails', __name__)
 

--- a/amivapi/events/queue.py
+++ b/amivapi/events/queue.py
@@ -59,7 +59,7 @@ def notify_signup_accepted(event_name, signup):
         email = signup['email']
 
     token = Signer(current_app.config['TOKEN_SECRET']).sign(
-            str(signup[id_field]).encode('utf-8'))
+        str(signup[id_field]).encode('utf-8'))
 
     if current_app.config.get('SERVER_NAME') is None:
         current_app.logger.warning("SERVER_NAME is not set. E-Mail links "

--- a/amivapi/events/validation.py
+++ b/amivapi/events/validation.py
@@ -4,14 +4,12 @@
 #          you to buy us beer if we meet and you like the software.
 
 """Event Validation."""
-
-import json
-import pytz
 from datetime import datetime
+import json
 
-from flask import g, current_app, request
-
-from jsonschema import SchemaError, Draft4Validator
+from flask import current_app, g, request
+from jsonschema import Draft4Validator, SchemaError
+import pytz
 
 
 class EventValidator(object):

--- a/amivapi/groups/__init__.py
+++ b/amivapi/groups/__init__.py
@@ -9,23 +9,22 @@ Also contains email management for group mailing lists
 
 And provides a helper function to check group permissions.
 """
+from datetime import datetime, timedelta
 
-from datetime import timedelta, datetime
 from flask import current_app
 
 from amivapi.cron import periodic
-from amivapi.utils import register_domain, register_validator
-
-from .mailing_lists import (
+from amivapi.groups.mailing_lists import (
     new_groups,
     new_members,
     removed_group,
     removed_member,
     updated_group,
     updated_user)
-from .model import groupdomain
-from .permissions import check_group_permissions
-from .validation import GroupValidator
+from amivapi.groups.model import groupdomain
+from amivapi.groups.permissions import check_group_permissions
+from amivapi.groups.validation import GroupValidator
+from amivapi.utils import register_domain, register_validator
 
 
 def init_app(app):

--- a/amivapi/groups/model.py
+++ b/amivapi/groups/model.py
@@ -6,13 +6,11 @@
 
 Contains models for groups and group mmeberships.
 """
+from bson import ObjectId
+from flask import current_app
 
 from amivapi.auth import AmivTokenAuth
 from amivapi.settings import EMAIL_REGEX
-
-from bson import ObjectId
-
-from flask import current_app
 
 
 class GroupAuth(AmivTokenAuth):

--- a/amivapi/ldap.py
+++ b/amivapi/ldap.py
@@ -7,9 +7,9 @@
 
 import re
 
-from flask import current_app
-from eve.methods.post import post_internal
 from eve.methods.patch import patch_internal
+from eve.methods.post import post_internal
+from flask import current_app
 from nethz import ldap
 
 from amivapi.utils import admin_permissions

--- a/amivapi/media.py
+++ b/amivapi/media.py
@@ -10,14 +10,15 @@ Saves Uploaded media to a folder specified in config['STORAGE_FOLDER']
 
 """
 
-import pytz
-from os import path, remove, makedirs, urandom
-import errno
+from base64 import b64encode
 from contextlib import contextmanager
 from datetime import datetime as dt
-from mimetypes import guess_type
-from base64 import b64encode
+import errno
 from imghdr import what
+from mimetypes import guess_type
+from os import makedirs, path, remove, urandom
+
+import pytz
 from werkzeug import secure_filename
 
 from amivapi.utils import register_validator

--- a/amivapi/studydocs/__init__.py
+++ b/amivapi/studydocs/__init__.py
@@ -8,11 +8,12 @@
 Contains settings for eve resource, special validation and email_confirmation
 logic needed for signup of non members to events.
 """
-
+from amivapi.studydocs.authorization import (
+    add_uploader_on_bulk_insert,
+    add_uploader_on_insert
+)
+from amivapi.studydocs.model import studydocdomain
 from amivapi.utils import register_domain
-
-from .model import studydocdomain
-from .authorization import add_uploader_on_insert, add_uploader_on_bulk_insert
 
 
 def init_app(app):

--- a/amivapi/tests/auth/fake_auth.py
+++ b/amivapi/tests/auth/fake_auth.py
@@ -6,8 +6,8 @@
 
 from contextlib import contextmanager
 
-from flask import g
 from eve.auth import BasicAuth
+from flask import g
 
 from amivapi.auth import AmivTokenAuth
 from amivapi.tests.utils import WebTest

--- a/amivapi/tests/auth/test_auth.py
+++ b/amivapi/tests/auth/test_auth.py
@@ -4,30 +4,30 @@
 #          you to buy us beer if we meet and you like the software.
 """Tests for auth functions."""
 
-from bson import ObjectId
 from base64 import b64encode
 from datetime import datetime, timedelta
 
+from bson import ObjectId
 from flask import g
-from werkzeug.exceptions import Unauthorized, Forbidden
+from werkzeug.exceptions import Forbidden, Unauthorized
 
 from amivapi.auth import (
-    AmivTokenAuth,
-    add_lookup_filter,
-    check_item_write_permission,
-    check_resource_write_permission,
     abort_if_not_public,
+    add_lookup_filter,
+    AmivTokenAuth,
     authenticate,
-    check_if_admin
+    check_if_admin,
+    check_item_write_permission,
+    check_resource_write_permission
 )
 from amivapi.auth.auth import (
-    only_if_auth_required,
     not_if_admin,
     not_if_admin_or_readonly_admin,
-    only_amiv_token_auth
+    only_amiv_token_auth,
+    only_if_auth_required
 )
+from amivapi.tests.auth.fake_auth import FakeAuthTest
 from amivapi.tests.utils import WebTest
-from .fake_auth import FakeAuthTest
 
 
 class AmivTokenAuthTest(WebTest):

--- a/amivapi/tests/auth/test_link_methods.py
+++ b/amivapi/tests/auth/test_link_methods.py
@@ -16,19 +16,19 @@ Note on link setup. The links in eve are a little inconsistent
 from copy import deepcopy
 import json
 
-from flask import Response, g
+from flask import g, Response
 
 from amivapi.auth.link_methods import (
+    _get_data as get_response_data,
     add_methods_to_item_links,
     add_methods_to_resource_links,
-    add_permitted_methods_after_update,
-    add_permitted_methods_after_insert,
     add_permitted_methods_after_fetch_item,
     add_permitted_methods_after_fetch_resource,
-    add_permitted_methods_for_home,
-    _get_data as get_response_data
+    add_permitted_methods_after_insert,
+    add_permitted_methods_after_update,
+    add_permitted_methods_for_home
 )
-from .fake_auth import FakeAuthTest
+from amivapi.tests.auth.fake_auth import FakeAuthTest
 from amivapi.tests.utils import WebTest
 
 

--- a/amivapi/tests/auth/test_session_expiry.py
+++ b/amivapi/tests/auth/test_session_expiry.py
@@ -9,8 +9,8 @@
 from datetime import timedelta
 from freezegun import freeze_time
 
-from amivapi.tests.utils import WebTest
 from amivapi.cron import run_scheduled_tasks
+from amivapi.tests.utils import WebTest
 
 
 class TestSessionExpiry(WebTest):

--- a/amivapi/tests/beverages/test_beverages.py
+++ b/amivapi/tests/beverages/test_beverages.py
@@ -6,8 +6,8 @@
 
 from datetime import datetime, timedelta
 
-from amivapi.tests import utils
 from amivapi.settings import DATE_FORMAT
+from amivapi.tests import utils
 
 
 class BeveragesTest(utils.WebTestNoAuth):

--- a/amivapi/tests/events/test_auth.py
+++ b/amivapi/tests/events/test_auth.py
@@ -5,8 +5,9 @@
 """Test event authorization"""
 
 from datetime import datetime
-from freezegun import freeze_time
 import json
+
+from freezegun import freeze_time
 
 from amivapi.tests.utils import WebTest
 

--- a/amivapi/tests/events/test_model.py
+++ b/amivapi/tests/events/test_model.py
@@ -70,13 +70,13 @@ class EventModelTest(WebTestNoAuth):
             "type": "object",
             "additionalProperties": False,
             'properties': {
-             'field1': {
-                 'type': 'string',
-                 'maxLength': 10
-             },
-             'field2': {
-                 'type': 'integer'
-             }},
+                'field1': {
+                    'type': 'string',
+                    'maxLength': 10
+                },
+                'field2': {
+                    'type': 'integer'
+                }},
             'required': ['field1']
         }))
 

--- a/amivapi/tests/events/test_projections.py
+++ b/amivapi/tests/events/test_projections.py
@@ -8,10 +8,11 @@
 - eventsignups.confirmed
 - eventsignups.position
 """
+from datetime import timedelta
+
+from freezegun import freeze_time
 
 from amivapi.tests.utils import WebTestNoAuth
-from freezegun import freeze_time
-from datetime import timedelta
 
 
 class EventProjectionTest(WebTestNoAuth):

--- a/amivapi/tests/fixtures.py
+++ b/amivapi/tests/fixtures.py
@@ -141,9 +141,9 @@ class FixtureMixin(object):
 
         # We iterate over the schema to fix missing fields with random values
         for field, field_def in schema.items():
-            if (field not in obj
-                    and field_def.get('required', False)
-                    and not field_def.get('readonly', False)):
+            if (field not in obj and
+                    field_def.get('required', False) and
+                    not field_def.get('readonly', False)):
                 # We need to add a value for the field to create a valid
                 # object
                 if 'default' in field_def:
@@ -222,8 +222,8 @@ class FixtureMixin(object):
         # to have relations to
         obj.setdefault('spots', random.randint(50, 500))
         if obj['spots']:
-            if ('time_register_start' not in obj
-                    and 'time_register_end' not in obj):
+            if ('time_register_start' not in obj and
+                    'time_register_end' not in obj):
                 obj['time_register_start'] = (
                     datetime.now(pytz.utc) - timedelta(
                         seconds=random.randint(0, 1000000)))
@@ -231,8 +231,8 @@ class FixtureMixin(object):
                     datetime.now(pytz.utc) + timedelta(
                         seconds=random.randint(0, 1000000)))
             else:
-                if ('time_register_start' not in obj
-                        or 'time_register_end' not in obj):
+                if ('time_register_start' not in obj or
+                        'time_register_end' not in obj):
                     raise BadFixtureException(
                         "Bad fixture: please specify either both "
                         "time_register_start and time_register_end or none")

--- a/amivapi/tests/fixtures.py
+++ b/amivapi/tests/fixtures.py
@@ -42,15 +42,15 @@ validators and will therefore reject random values.
 See preprocess_sessions or preprocess_events below for examples
 """
 
+from datetime import date, datetime, timedelta
+from os.path import dirname, join
 import random
 import string
-import pytz
-from os.path import join, dirname
-from bson import ObjectId
-from datetime import datetime, date, timedelta
 
-from werkzeug.datastructures import FileStorage
+from bson import ObjectId
 from eve.methods.post import post_internal
+import pytz
+from werkzeug.datastructures import FileStorage
 
 from amivapi.settings import EMAIL_REGEX
 from amivapi.utils import admin_permissions

--- a/amivapi/tests/groups/test_permissions.py
+++ b/amivapi/tests/groups/test_permissions.py
@@ -7,10 +7,9 @@
 Since this hook will be added for all requests (the after auth hook) and this
 is tested for auth.py we only get get on resource level to test functionality.
 """
+from flask import g
 
 from amivapi.tests.utils import WebTest
-
-from flask import g
 
 
 class PermissionsTest(WebTest):

--- a/amivapi/tests/groups/test_validation.py
+++ b/amivapi/tests/groups/test_validation.py
@@ -175,9 +175,9 @@ class ValidationTest(WebTest):
         r = self.load_fixture({'groups': [
             {'name': 'test', 'receive_from': ['a', 'b', 'c']}
         ]})
-        id = str(r[0]['_id'])
+        ID = str(r[0]['_id'])
         etag = r[0]['_etag']
         token = self.get_root_token()
         subset = {'receive_from': ['a', 'b']}
-        self.api.patch("/groups/" + id, data=subset, token=token,
+        self.api.patch("/groups/" + ID, data=subset, token=token,
                        headers={'If-Match': etag}, status_code=200)

--- a/amivapi/tests/joboffers/test_joboffers.py
+++ b/amivapi/tests/joboffers/test_joboffers.py
@@ -6,10 +6,10 @@
 
 from datetime import datetime, timedelta
 from io import BytesIO
-from os.path import join, dirname
+from os.path import dirname, join
 
-from amivapi.tests import utils
 from amivapi.settings import DATE_FORMAT
+from amivapi.tests import utils
 
 pdfpath = join(dirname(__file__), "../fixtures", 'test.pdf')
 lenapath = join(dirname(__file__), "../fixtures", 'lena.png')

--- a/amivapi/tests/ldap_integration.py
+++ b/amivapi/tests/ldap_integration.py
@@ -38,8 +38,8 @@ LDAP_PASS = 'YOUR_LDAP_ACCOUNT_PASSWORD'
 
 from os import getenv
 
-from amivapi.tests.utils import WebTest
 from amivapi.ldap import ldap_connector
+from amivapi.tests.utils import WebTest
 
 
 class LdapIntegrationTest(WebTest):

--- a/amivapi/tests/test_cron.py
+++ b/amivapi/tests/test_cron.py
@@ -9,16 +9,16 @@
 from datetime import datetime, timedelta
 from freezegun import freeze_time
 
-from .utils import WebTestNoAuth
 from amivapi import cron
 from amivapi.cron import (
-    schedulable,
-    schedule_task,
-    periodic,
-    schedule_once_soon,
-    run_scheduled_tasks,
     NotSchedulable,
+    periodic,
+    run_scheduled_tasks,
+    schedulable,
+    schedule_once_soon,
+    schedule_task
 )
+from amivapi.tests.utils import WebTestNoAuth
 
 
 class CronTest(WebTestNoAuth):

--- a/amivapi/tests/test_media.py
+++ b/amivapi/tests/test_media.py
@@ -5,8 +5,8 @@
 
 """Test Media handling."""
 
-from os.path import join, dirname
 from io import BytesIO
+from os.path import dirname, join
 from werkzeug.datastructures import FileStorage
 
 from amivapi.media import ignore_not_found

--- a/amivapi/tests/test_media.py
+++ b/amivapi/tests/test_media.py
@@ -140,4 +140,4 @@ class MediaTest(WebTestNoAuth):
 
         self.api.get(obj['test_file']['file'], headers={
             'If-Modified-Since': 'Mon, 12 Dec 2016 12:23:46 GMT'},
-                     status_code=200)
+            status_code=200)

--- a/amivapi/tests/users/test_security.py
+++ b/amivapi/tests/users/test_security.py
@@ -9,11 +9,11 @@ Includes item and field permissions as well as password hashing.
 
 from bson import ObjectId
 
+from passlib.hash import pbkdf2_sha256
+
 from amivapi.tests import utils
 from amivapi.users.security import (
     hash_on_insert, hash_on_update)
-
-from passlib.hash import pbkdf2_sha256
 
 
 class PasswordHashing(utils.WebTestNoAuth):

--- a/amivapi/tests/utils.py
+++ b/amivapi/tests/utils.py
@@ -4,24 +4,24 @@
 #          you to buy us beer if we meet and you like the software.
 """General testing utilities."""
 
-import sys
+from itertools import count
 import json
-import unittest
 import os
 from shutil import rmtree
+import sys
 from tempfile import mkdtemp
-from itertools import count
-from pymongo import MongoClient
-from bson import ObjectId
-from passlib.context import CryptContext
+import unittest
 
+from bson import ObjectId
 from flask import g
 from flask.testing import FlaskClient
 from flask.wrappers import Response
+from passlib.context import CryptContext
+from pymongo import MongoClient
 
+from amivapi import bootstrap
 from amivapi.settings import ROOT_PASSWORD
 from amivapi.tests.fixtures import FixtureMixin
-from amivapi import bootstrap
 
 
 class TestClient(FlaskClient):

--- a/amivapi/utils.py
+++ b/amivapi/utils.py
@@ -5,14 +5,15 @@
 """Utilities."""
 
 
-import smtplib
-from email.mime.text import MIMEText
-from copy import deepcopy
 from contextlib import contextmanager
+from copy import deepcopy
+from email.mime.text import MIMEText
+import smtplib
 
-from flask import request, g, current_app as app
-from eve.utils import config
 from eve.io.mongo import Validator
+from eve.utils import config
+from flask import current_app as app
+from flask import g, request
 
 
 @contextmanager


### PR DESCRIPTION
I locally use a stricter version of flake8. I fixed all the errors I get, which are not covered in the projects flake8 settings.

The three commits include:

1. import ordering by Google Styleguide (https://google.github.io/styleguide/pyguide.html#Imports_formatting).

- Imports are in three groups: stdlib, external and internal
- no relative imports
- imports alphabetically (case insensitive)

2. Variables may not shadow builtins

3. Various errors which somehow slipped earlier, mostly wrong intendation.