### PR TITLE
Make flake8 enforce import order and no builtin shadowing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 
 """Install amivapi. Provide the amivapi command."""
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 with open('LICENSE') as f:
     LICENSE = f.read()

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,14 @@ deps =
     -rrequirements.txt
 
 [testenv:flake8]
-deps = flake8
+deps =
+    flake8
+    flake8-import-order
+    flake8-builtins
 commands = flake8 amivapi
 
 [flake8]
 max-line-length = 80
+application-import-names = amivapi
+import-order-style = google
+ignore = I201

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,17 @@ commands = flake8 amivapi
 
 [flake8]
 max-line-length = 80
+# This tells flake8-import-order to treat everything from the amivapi package
+# as a local module. Therefore it belongs into the third group of imports.
 application-import-names = amivapi
+# This tells flake8-import-order to follow the google style guidelines,
+# including being case insensitive for ordering and putting "import ..." and
+# "from ... import ..." statements in the same group.
 import-order-style = google
+# I201: Missing newline between sections or imports.
+# We disable this, because this requires empty lines between imports from
+# different external libraries. We sometimes use more than 5 different
+# libraries in the same file, the rule makes this harder to read.
+# Furthermore it is not part of the google style guide.
+# https://google.github.io/styleguide/pyguide.html#Imports_formatting
 ignore = I201


### PR DESCRIPTION
I added plugins to flake8 for further rule checking. This should be merged after the cleanup branch, which fixes all errors discovered by these settings.

For me it also works with my editor, if I install the two plugins system wide and add these lines(same as tox.ini) to my global flake8 config:

```
ignore = I201
application-import-names = amivapi
import-order-style = google
```