### PR TITLE
LDAP improvements the third

### DIFF
--- a/amivapi/auth/sessions.py
+++ b/amivapi/auth/sessions.py
@@ -15,9 +15,9 @@ from eve.methods.patch import patch_internal
 from eve.utils import config, debug_error_message
 from flask import abort, current_app as app
 
+from amivapi import ldap
 from amivapi.auth import AmivTokenAuth
 from amivapi.cron import periodic
-from amivapi.ldap import ldap_connector
 from amivapi.utils import admin_permissions
 
 
@@ -116,10 +116,9 @@ def process_login(items):
         password = item['password']
 
         # LDAP
-        if (config.ENABLE_LDAP and
-                ldap_connector.authenticate_user(username, password)):
+        if (config.ENABLE_LDAP and ldap.authenticate_user(username, password)):
             # Success, sync user and get token
-            updated = ldap_connector.sync_one(username)
+            updated = ldap.sync_one(username)
             _prepare_token(item, updated['_id'])
             app.logger.info(
                 "User '%s' was authenticated with LDAP" % username)

--- a/amivapi/bootstrap.py
+++ b/amivapi/bootstrap.py
@@ -20,12 +20,12 @@ from amivapi import (
     events,
     groups,
     joboffers,
+    ldap,
     media,
     studydocs,
     users,
     utils
 )
-from amivapi.ldap import ldap_connector
 from amivapi.settings import DEFAULT_CONFIG_FILENAME
 
 
@@ -62,7 +62,7 @@ def create_app(config_file=DEFAULT_CONFIG_FILENAME, **kwargs):
 
     # Create LDAP connector
     if app.config['ENABLE_LDAP']:
-        ldap_connector.init_app(app)
+        ldap.init_app(app)
 
     # Initialize modules to register resources, validation, hooks, auth, etc.
     users.init_app(app)

--- a/amivapi/cli.py
+++ b/amivapi/cli.py
@@ -14,7 +14,7 @@ from ruamel import yaml
 
 from amivapi.bootstrap import create_app
 from amivapi.cron import run_scheduled_tasks
-from amivapi.ldap import ldap_connector
+from amivapi import ldap
 from amivapi.settings import DEFAULT_CONFIG_FILENAME, FORWARD_DIR, STORAGE_DIR
 
 
@@ -56,11 +56,11 @@ def ldap_sync(config, sync_all, nethz):
     else:
         with app.test_request_context():
             if sync_all:
-                res = ldap_connector.sync_all()
+                res = ldap.sync_all()
                 echo("Synchronized %i users." % len(res))
             else:
                 for user in nethz:
-                    if ldap_connector.sync_one(user) is not None:
+                    if ldap.sync_one(user) is not None:
                         echo("Succesfully synchronized '%s'." % user)
                     else:
                         echo("Could not synchronize '%s'." % user)

--- a/amivapi/groups/model.py
+++ b/amivapi/groups/model.py
@@ -210,7 +210,7 @@ groupdomain = {
                 },
                 'required': True,
                 'only_self_or_moderator': True,
-                'unique_combination': ['group']
+                'unique_combination': ['group'],
             },
             'expiry': {
                 'type': 'datetime',

--- a/amivapi/groups/model.py
+++ b/amivapi/groups/model.py
@@ -210,7 +210,7 @@ groupdomain = {
                 },
                 'required': True,
                 'only_self_or_moderator': True,
-                'unique_combination': ['group'],
+                'unique_combination': ['group']
             },
             'expiry': {
                 'type': 'datetime',

--- a/amivapi/tests/ldap_integration.py
+++ b/amivapi/tests/ldap_integration.py
@@ -38,7 +38,7 @@ LDAP_PASS = 'YOUR_LDAP_ACCOUNT_PASSWORD'
 
 from os import getenv
 
-from amivapi.ldap import ldap_connector
+from amivapi import ldap
 from amivapi.tests.utils import WebTest
 
 
@@ -63,125 +63,35 @@ class LdapIntegrationTest(WebTest):
         }
         self.data['email'] = "%s@ethz.ch" % self.data['nethz']
         self.password = getenv('ldap_password')
-
-        self.assertTrue(
-            all(self.data.values()),
-            "Some environment variables are missing!")
-
         # Python2 fix: Make everything unicode
         for key, value in self.data.items():
             if type(value) is bytes:
                 self.data[key] = value.decode("utf-8")
 
-    def test_escape(self):
-        """Test proper escaping of all characters."""
-        to_escape = "*()\\" + chr(0)
-        expected = r"\\2A\\28\\29\\5C\\00"
+    def test_variables(self):
+        """Assert all environment variables are set."""
+        self.assertTrue(
+            all(self.data.values()),
+            "Some environment variables are missing!")
 
-        self.assertEqual(ldap_connector._escape(to_escape), expected)
+    def test_login(self):
+        """Test that post to sessions works."""
+        credentials = {'username': self.data['nethz'],
+                       'password': self.password}
+        self.api.post('/sessions', data=credentials, status_code=201)
 
     def test_authenticate_user(self):
         """Assert authentication is successful."""
         with self.app.app_context():
             self.assertTrue(
-                ldap_connector.authenticate_user(
+                ldap.authenticate_user(
                     self.data['nethz'], self.password)
             )
 
-    def test_find_user(self):
-        """Assert user can be found and data is correct.
-
-        Note: This also means that a password is not in the ldap data.
-        (Which is nice, since we don't want to store that.)
-        """
-        with self.app.app_context():
-            user = ldap_connector.find_user(self.data['nethz'])
-            self.assertIsNotNone(user)
-            self.assertEqual(user, self.data)
-
-    def test_find_members(self):
-        """Assert that find_members works.
-
-        - All imported users are members
-        - Our user is in the list.
-        """
-        with self.app.app_context():
-            members = list(ldap_connector.find_members())
-
-            # Assert something is found
-            self.assertTrue(members)
-
-            # Assert only members are imported
-            everyone_is_member = all(member['membership'] == 'regular'
-                                     for member in members)
-
-            self.assertTrue(everyone_is_member)
-
-            # Assert user is found
-            user_data = [member for member in members
-                         if member['nethz'] == self.data['nethz']]
-            self.assertEqual(user_data, self.data)
-
-    def test_compare_and_update(self):
-        """Assert that compare_and_update only changes necessary fields."""
-        fixtures = self.load_fixture({
-            'users': [{'firstname': u'db', 'lastname': u'db'}]})
-        user_id = fixtures[0]['_id']
-
-        with self.app.test_request_context():
-            # Fake db data, only firstname should change
-            fake_db_data = {'_id': user_id,
-                            'firstname': 'db',
-                            'lastname': 'ldap'}
-            fake_ldap_data = {'firstname': 'ldap',
-                              'lastname': 'ldap'}
-
-            ldap_connector.compare_and_update(fake_db_data, fake_ldap_data)
-
-            # Get user from database and compare
-            user = self.db['users'].find_one({'_id': user_id})
-            self.assertEqual(user['firstname'], 'ldap')
-            self.assertEqual(user['lastname'], 'db')
-
-    def test_update_only_upgrades_membership(self):
-        """Assert that the update only changes membership if none."""
-        data_no_change = {'_id': 24 * '0',
-                          'nethz': 'nochange', 'membership': u"honorary"}
-        data_change = {'_id': 24 * '1',
-                       'nethz': 'change', 'membership': u"none"}
-        self.load_fixture({'users': [data_no_change, data_change]})
-
-        with self.app.test_request_context():
-            ldap_data = {'membership': u'regular'}
-
-            ldap_connector.compare_and_update(data_no_change, ldap_data)
-            ldap_connector.compare_and_update(data_change, ldap_data)
-
-            user_no_change = self.db['users'].find_one({'nethz': 'nochange'})
-            user_change = self.db['users'].find_one({'nethz': 'change'})
-            self.assertEqual(user_no_change['membership'],
-                             data_no_change['membership'])
-            self.assertEqual(user_change['membership'],
-                             ldap_data['membership'])
-
-    def test_update_doesnt_change_email(self):
-        """Assert that mail is never changed."""
-        data_no_change = {'nethz': 'nochange', 'email': u"any@thing.ch"}
-        self.load_fixture({'users': [data_no_change]})
-
-        with self.app.test_request_context():
-            ldap_data = {'email': u'some@thing.ch'}
-
-            ldap_connector.compare_and_update(data_no_change, ldap_data)
-
-            user_no_change = self.db['users'].find_one({'nethz': 'nochange'})
-            self.assertEqual(user_no_change['email'],
-                             data_no_change['email'])
-
-    def test_sync_one_import(self):
+    def test_sync_one(self):
         """Assert synchronizing one user works."""
         with self.app.test_request_context():
-            user = ldap_connector.sync_one(self.data['nethz'])
+            user = ldap.sync_one(self.data['nethz'])
 
             # Double check with database
             check_user = self.db['users'].find_one(
@@ -192,71 +102,13 @@ class LdapIntegrationTest(WebTest):
                 self.assertEqual(user[key], self.data[key])
                 self.assertEqual(check_user[key], self.data[key])
 
-    def test_sync_one_update(self):
-        """Same as before, but the user exists now before ldap sync."""
-        self.load_fixture({'users': [{'nethz': self.data['nethz'],
-                                      'membership': u"none"}]})
-
-        with self.app.test_request_context():
-            user = ldap_connector.sync_one(self.data['nethz'])
-
-            # Double check with database
-            check_user = self.db['users'].find_one(
-                {'nethz': self.data['nethz']})
-
-            # Compare by key since self.data doesnt have fields with
-            # email won't be changed, so don't check that
-            keys_except_mail = (key for key in self.data if key != "email")
-            for key in keys_except_mail:
-                self.assertEqual(user[key], self.data[key])
-                self.assertEqual(check_user[key], self.data[key])
-
     def test_sync_all(self):
         """Test sync all imports users by checking the test user."""
         with self.app.test_request_context():
-            ldap_connector.sync_all()
+            ldap.sync_all()
 
             # Find test user
             user = self.db['users'].find_one({'nethz': self.data['nethz']})
 
             for key in self.data:
                 self.assertEqual(user[key], self.data[key])
-
-    def test_sync_all_update(self):
-        """Same as before, but the user exists now before ldap sync."""
-        self.load_fixture({'users': [{'nethz': self.data['nethz'],
-                                      'membership': u"none"}]})
-
-        with self.app.test_request_context():
-            ldap_connector.sync_all()
-
-            # Find test user
-            user = self.db['users'].find_one({'nethz': self.data['nethz']})
-
-            # email won't be changed, so don't check that
-            keys_except_mail = (key for key in self.data if key != "email")
-            for key in keys_except_mail:
-                self.assertEqual(user[key], self.data[key])
-
-    def test_import_on_login(self):
-        """Test that login imports the user."""
-        data = {'username': self.data['nethz'], 'password': self.password}
-        self.api.post("/sessions", data=data, status_code=201)
-
-        user = self.db['users'].find_one({'nethz': self.data['nethz']})
-        self.assertIsNotNone(user)
-
-    def test_update_on_login(self):
-        """Test login again, but this time the user already exists."""
-        self.load_fixture({'users': [{'nethz': self.data['nethz'],
-                                      'membership': u"none"}]})
-
-        data = {'username': self.data['nethz'], 'password': self.password}
-        self.api.post("/sessions", data=data, status_code=201)
-
-        # Comparison necessary to make sure it was updated
-        # email won't be changed, so don't check that
-        user = self.db['users'].find_one({'nethz': self.data['nethz']})
-        keys_except_mail = (key for key in self.data if key != "email")
-        for key in keys_except_mail:
-            self.assertEqual(user[key], self.data[key])

--- a/amivapi/tests/test_ldap.py
+++ b/amivapi/tests/test_ldap.py
@@ -11,44 +11,32 @@ There is another file, "ldap_integration.py", which can be used to test
 integration with the real ldap. More info there.
 """
 
-from unittest.mock import MagicMock, patch
+from mock import MagicMock, patch, call
 
 from amivapi import ldap
-from amivapi.tests.utils import WebTest, WebTestNoAuth
-
-MOCK_LDAP_DATA = {
-    'testuser1': {
-        'password': 'testpass1',
-
-    },
-    'testuser2': {
-        'password': 'testpass2',
-
-    }
-}
-
-EXPECTED_RESULTS = {
-    'testuser1': {
-
-    },
-    'testuser2': {
-
-    },
-
-}
+from amivapi.tests.utils import WebTestNoAuth
 
 
-class LdapAuthTest(WebTest):
-    """Tests for LDAP auth."""
+class LdapTest(WebTestNoAuth):
+    """Tests for LDAP with a mock connection."""
 
     def setUp(self, *args, **kwargs):
         """Extended setUp, enable LDAP and replace it with a Mock object."""
-        self.test_config['ENABLE_LDAP'] = True
-        self.test_config['LDAP_USER'] = self.test_config['LDAP_PASS'] = "Bla."
-        self.mock_ldap = MagicMock()
-        # When instantiated, it will return the mock object to use in the tests
-        ldap.AuthenticatedLdap = MagicMock(return_value=self.mock_ldap)
-        super(LdapAuthTest, self).setUp(*args, **kwargs)
+        super(LdapTest, self).setUp(*args, **kwargs)
+
+        self.app.config['ENABLE_LDAP'] = True
+        self.mock_ldap = self.app.config['ldap_connector'] = MagicMock()
+
+    def test_init_app(self):
+        """Test that init app uses correct credentials stored connector."""
+        self.app.config['LDAP_USER'] = 'test'
+        self.app.config['LDAP_PASS'] = 'T3ST'
+        to_patch = 'amivapi.ldap.AuthenticatedLdap'
+        with patch(to_patch, return_value='initialized') as init:
+            ldap.init_app(self.app)
+
+            init.assert_called_with('test', 'T3ST')
+            self.assertEqual(self.app.config['ldap_connector'], 'initialized')
 
     def test_ldap_auth(self):
         """Test that ldap can authenticate a user."""
@@ -62,7 +50,7 @@ class LdapAuthTest(WebTest):
 
         # We patch sync one to return an existing user
         # sync one is tested separately
-        sync = 'amivapi.ldap.LdapConnector.sync_one'
+        sync = 'amivapi.ldap.sync_one'
         _id = {'_id': self.new_object('users')["_id"]}
         with patch(sync, return_value=_id) as patched_sync:
             # Auth with ldap succeeds
@@ -73,21 +61,16 @@ class LdapAuthTest(WebTest):
             # But we will assert that sync_one is called for successful auth
             patched_sync.assert_called()
 
-
-class LdapTest(WebTestNoAuth):
-    """Tests for various LDAP functions like sync."""
-
     def test_escape(self):
         """Test proper escaping of all characters."""
-        to_escape = "*()\\" + chr(0)
-        expected = r"\\2A\\28\\29\\5C\\00"
+        to_escape = "thisisok*()\\" + chr(0)
+        expected = r"thisisok\\2A\\28\\29\\5C\\00"
 
         self.assertEqual(ldap._escape(to_escape), expected)
 
-
-    def test_filter(self):
-        """The received LDAP data can look weird. Test that it is filtered."""
-        ldap_data = {
+    def fake_ldap_data(self, **kwargs):
+        """Produce basic fake ldap data to test filter."""
+        data = {
             'cn': ['pablo'],
             'swissEduPersonMatriculationNumber': '01234567',
             'givenName': ['P'],
@@ -97,223 +80,196 @@ class LdapTest(WebTestNoAuth):
                    'Informationstechnologie und Elektrotechnik'],
             'some_random_field': 'abc',
         }
+        data.update(kwargs)
+        return data
 
-        with self.app.app_context():
-            filtered = ldap._filter_data(ldap_data)
-
-        expected = {
+    def fake_filtered_data(self):
+        """Some data that is a valid output of _filter_data."""
+        return {
             'nethz': 'pablo',
+            'email': 'pablo@ethz.ch',  # this will be auto-generated
             'firstname': 'P',
             'lastname': 'Ablo',
             'department': 'itet',
-            'membership': 'regular'
+            'membership': 'regular',
+            'gender': 'female',
+            'legi': '01234567'
         }
 
-        self.assertEqual(filtered, expected)
-
-'''
-
-# No Pablo in database yet
-        token = self.get_root_token()
-        self.api.get('/users/pablo', status_code=404, token=token)
-
-        # We need to be able to find, authenticate and sync the user
-        ldap_user = {
-            'cn': ['pablo'],
-            'swissEduPersonMatriculationNumber': '01234567',
-            'givenName': ['P'],
-            'sn': ['Ablo'],
-            'swissEduPersonGender': '0',
-            'ou': ['VSETH Mitglied']
-        }
-
-        self.mock_ldap.search = Mock(return_value=[ldap_user])
-
-
-
-
-    def setUp(self, *args, **kwargs):
-        """Extended setUp, replace the ldap in ldap_connector.
-        """
-        self.test_config['ENABLE_LDAP'] = True
-        ldap_connector.ldap = MockLdap()
-
-        super(LdapTest, self).setUp(*args, **kwargs)
-
-
-
-    def test_authenticate_user(self):
-        """Assert authentication is successful."""
+    def test_filter_data(self):
+        """The received LDAP data can look weird. Test that it is filtered."""
         with self.app.app_context():
-            self.assertTrue(
-                ldap_connector.authenticate_user('testuser1', 'testpass1'))
+            filtered = ldap._filter_data(self.fake_ldap_data())
+            expected = self.fake_filtered_data()
 
-    def test_find_user(self):
-        """Assert user can be found."""
+            self.assertEqual(filtered, expected)
+
+    def test_filter_gender(self):
+        """ Test parsing of gender field."""
         with self.app.app_context():
-            user = ldap_connector.find_user('testuser1')
-            self.assertIsNotNone(user)
-            self.assertEqual(user, self.data)
+            female_data = self.fake_ldap_data(swissEduPersonGender='0')
+            female_filtered = ldap._filter_data(female_data)
+            self.assertTrue(female_filtered['gender'] == 'female')
 
-    def test_find_members(self):
-        """Assert that find_members works.
+            male_data = self.fake_ldap_data(swissEduPersonGender='1')
+            male_filtered = ldap._filter_data(male_data)
+            self.assertTrue(male_filtered['gender'] == 'male')
 
-        - All imported users are members
-        - Our user is in the list.
-        """
+    def test_filter_department(self):
+        """Test deparment filtering. The 'ou' entry has to be checked."""
         with self.app.app_context():
-            members = list(ldap_connector.find_members())
+            tests = (
+                ('D-ITET', 'itet'),
+                ('D-MAVT', 'mavt'),
+                ('D-Somethingelse', 'other')
+            )
+            for ldap_value, api_value in tests:
+                data = self.fake_ldap_data(ou=[ldap_value])
+                filtered = ldap._filter_data(data)
+                self.assertTrue(filtered['department'] == api_value)
 
-            # Assert something is found
-            self.assertTrue(members)
+    def test_filter_membership(self):
+        """Test membership filtering. The 'ou' entry has to be checked."""
+        with self.app.app_context():
+            # ou must contain 'VSETH Mitglied' and any of the specified 'ou'
+            # values
+            self.app.config['LDAP_MEMBER_OU_LIST'] = [
+                'test_value', 'other_value'
+            ]
 
-            # Assert only members are imported
-            everyone_is_member = all(member['membership'] == 'regular'
-                                     for member in members)
+            tests = (
+                # (ou, expected result)
+                (['VSETH Mitglied', 'test_value'], 'regular'),
+                (['VSETH Mitglied', 'other_value'], 'regular'),
+                # Something missing
+                (['VSETH Mitglied'], 'none'),
+                (['test_value'], 'none'),
+                (['other_value'], 'none'),
+                ([], 'none'),
+            )
 
-            self.assertTrue(everyone_is_member)
+            for (ou_values, result) in tests:
+                data = self.fake_ldap_data(ou=ou_values)
+                filtered = ldap._filter_data(data)
+                self.assertTrue(filtered['membership'] == result)
 
-            # Assert user is found
-            user_data = [member for member in members
-                         if member['nethz'] == self.data['nethz']]
-            self.assertEqual(user_data, self.data)
+    def test_create_user(self):
+        """Test the 'create' part of _create_or_update_user."""
+        new_user = self.fake_filtered_data()
 
-    def test_compare_and_update(self):
-        """Assert that compare_and_update only changes necessary fields."""
-        fixtures = self.load_fixture({
-            'users': [{'firstname': u'db', 'lastname': u'db'}]})
-        user_id = fixtures[0]['_id']
-
-        with self.app.test_request_context():
-            # Fake db data, only firstname should change
-            fake_db_data = {'_id': user_id,
-                            'firstname': 'db',
-                            'lastname': 'ldap'}
-            fake_ldap_data = {'firstname': 'ldap',
-                              'lastname': 'ldap'}
-
-            ldap_connector.compare_and_update(fake_db_data, fake_ldap_data)
-
-            # Get user from database and compare
-            user = self.db['users'].find_one({'_id': user_id})
-            self.assertEqual(user['firstname'], 'ldap')
-            self.assertEqual(user['lastname'], 'db')
-
-    def test_update_only_upgrades_membership(self):
-        """Assert that the update only changes membership if none."""
-        data_no_change = {'_id': 24 * '0',
-                          'nethz': 'nochange', 'membership': u"honorary"}
-        data_change = {'_id': 24 * '1',
-                       'nethz': 'change', 'membership': u"none"}
-        self.load_fixture({'users': [data_no_change, data_change]})
+        # User not found yet
+        self.api.get('/users/%s' % new_user['nethz'], status_code=404)
 
         with self.app.test_request_context():
-            ldap_data = {'membership': u'regular'}
+            ldap._create_or_update_user(new_user)
 
-            ldap_connector.compare_and_update(data_no_change, ldap_data)
-            ldap_connector.compare_and_update(data_change, ldap_data)
+        # User exists now
+        self.api.get('/users/%s' % new_user['nethz'], status_code=200)
 
-            user_no_change = self.db['users'].find_one({'nethz': 'nochange'})
-            user_change = self.db['users'].find_one({'nethz': 'change'})
-            self.assertEqual(user_no_change['membership'],
-                             data_no_change['membership'])
-            self.assertEqual(user_change['membership'],
-                             ldap_data['membership'])
+    def test_update_user(self):
+        """Test the 'patch' part of _create_or_patch_user."""
+        # The user is in the database. Now change a few things and verify
+        # patch with original data does the correct thing
+        tests = (
+            # (field, db_value, ldap_value, change_expected)
+            ('firstname', 'old', 'new', True),
+            ('lastname', 'old', 'new', True),
+            ('department', 'mavt', 'itet', True),
+            ('gender', 'male', 'female', True),
+            ('legi', '76543210', '01234567', True),
+            # Membership is only upgraded
+            ('membership', 'none', 'regular', True),
+            ('membership', 'regular', 'none', False),
+            ('membership', 'honorary', 'regular', False),
+            ('membership', 'honorary', 'none', False),
+            ('membership', 'extraordinary', 'regular', False),
+            ('membership', 'extraordinary', 'none', False),
+            # email will not be changed
+            ('email', 'old@mail.de', 'new@mail.de', False)
+        )
 
-    def test_update_doesnt_change_email(self):
-        """Assert that mail is never changed."""
-        data_no_change = {'nethz': 'nochange', 'email': u"any@thing.ch"}
-        self.load_fixture({'users': [data_no_change]})
+        for ind, (field, db_value, ldap_value, change) in enumerate(tests):
+            # Create a new user for every test
+            self.new_object('users', nethz=str(ind), **{field: db_value})
+            ldap_data = {'nethz': str(ind), field: ldap_value}
 
-        with self.app.test_request_context():
-            ldap_data = {'email': u'some@thing.ch'}
+            with self.app.test_request_context():
+                result = ldap._create_or_update_user(ldap_data)
 
-            ldap_connector.compare_and_update(data_no_change, ldap_data)
+            if change:
+                self.assertEqual(result[field], ldap_value)
+            else:
+                self.assertEqual(result[field], db_value)
 
-            user_no_change = self.db['users'].find_one({'nethz': 'nochange'})
-            self.assertEqual(user_no_change['email'],
-                             data_no_change['email'])
+    def test_search(self):
+        """Test that ldap is correctly queried."""
+        test_query = "äüáíðáßðöó"
+        attr = [
+            'cn',
+            'swissEduPersonMatriculationNumber',
+            'givenName',
+            'sn',
+            'swissEduPersonGender',
+            'ou'
+            ]
+        mock_results = [1, 2, 3]
+        # Mock ldap query
 
-    def test_sync_one_import(self):
-        """Assert synchronizing one user works."""
-        with self.app.test_request_context():
-            user = ldap_connector.sync_one(self.data['nethz'])
+        mock_search = MagicMock(return_value=mock_results)
+        self.app.config['ldap_connector'].search = mock_search
+        # Mock _filter_data to check results
+        with patch('amivapi.ldap._filter_data') as mock_filter:
+            with self.app.app_context():
+                result = ldap._search(test_query)
 
-            # Double check with database
-            check_user = self.db['users'].find_one(
-                {'nethz': self.data['nethz']})
+                # Verify correct query
+                mock_search.assert_called_with(test_query, attributes=attr)
 
-            # Compare by key since self.data doesnt have fields with _
-            for key in self.data:
-                self.assertEqual(user[key], self.data[key])
-                self.assertEqual(check_user[key], self.data[key])
+                # Assert _filter_data is called with ldap results
+                for ind, _ in enumerate(result):
+                    mock_filter.assert_called_with(mock_results[ind])
 
-    def test_sync_one_update(self):
-        """Same as before, but the user exists now before ldap sync."""
-        self.load_fixture({'users': [{'nethz': self.data['nethz'],
-                                      'membership': u"none"}]})
+    def test_sync_one_found(self):
+        """Sync one queries ldap and creates user."""
+        search_results = (i for i in [1])  # Mock generator
+        search = 'amivapi.ldap._search'
+        create = 'amivapi.ldap._create_or_update_user'
+        with patch(search, return_value=search_results) as mock_search:
+            with patch(create, return_value=2) as mock_create:
+                query = "Abcsdi123"
+                result = ldap.sync_one(query)
 
-        with self.app.test_request_context():
-            user = ldap_connector.sync_one(self.data['nethz'])
+                self.assertEqual(result, 2)
+                mock_search.assert_called_with('(cn=%s)' % query)
+                mock_create.assert_called_with(1)
 
-            # Double check with database
-            check_user = self.db['users'].find_one(
-                {'nethz': self.data['nethz']})
+    def test_sync_one_no_results(self):
+        """Test if sync one return None if there are no results."""
+        search_results = (i for i in [])  # Mock generator
+        search = 'amivapi.ldap._search'
+        create = 'amivapi.ldap._create_or_update_user'
+        with patch(search, return_value=search_results):
+            with patch(create) as mock_create:
+                query = "query"
+                result = ldap.sync_one(query)
 
-            # Compare by key since self.data doesnt have fields with
-            # email won't be changed, so don't check that
-            keys_except_mail = (key for key in self.data if key != "email")
-            for key in keys_except_mail:
-                self.assertEqual(user[key], self.data[key])
-                self.assertEqual(check_user[key], self.data[key])
+                self.assertEqual(result, None)
+                mock_create.assert_not_called()
 
     def test_sync_all(self):
-        """Test sync all imports users by checking the test user."""
-        with self.app.test_request_context():
-            ldap_connector.sync_all()
+        """Test if sync_all contructs the query correctly and creates users."""
+        # Make ou list shorter
+        self.app.config['LDAP_MEMBER_OU_LIST'] = ['a', 'b']
+        expected_query = '(& (ou=VSETH Mitglied) (| (ou=a)(ou=b)) )'
+        search_results = (i for i in [1, 2])
+        search = 'amivapi.ldap._search'
+        create = 'amivapi.ldap._create_or_update_user'
 
-            # Find test user
-            user = self.db['users'].find_one({'nethz': self.data['nethz']})
+        with patch(search, return_value=search_results) as mock_search:
+            with patch(create, return_value=3) as mock_create:
+                with self.app.app_context():
+                    result = ldap.sync_all()
 
-            for key in self.data:
-                self.assertEqual(user[key], self.data[key])
-
-    def test_sync_all_update(self):
-        """Same as before, but the user exists now before ldap sync."""
-        self.load_fixture({'users': [{'nethz': self.data['nethz'],
-                                      'membership': u"none"}]})
-
-        with self.app.test_request_context():
-            ldap_connector.sync_all()
-
-            # Find test user
-            user = self.db['users'].find_one({'nethz': self.data['nethz']})
-
-            # email won't be changed, so don't check that
-            keys_except_mail = (key for key in self.data if key != "email")
-            for key in keys_except_mail:
-                self.assertEqual(user[key], self.data[key])
-
-    def test_import_on_login(self):
-        """Test that login imports the user."""
-        data = {'username': self.data['nethz'], 'password': self.password}
-        self.api.post("/sessions", data=data, status_code=201)
-
-        user = self.db['users'].find_one({'nethz': self.data['nethz']})
-        self.assertIsNotNone(user)
-
-    def test_update_on_login(self):
-        """Test login again, but this time the user already exists."""
-        self.load_fixture({'users': [{'nethz': self.data['nethz'],
-                                      'membership': u"none"}]})
-
-        data = {'username': self.data['nethz'], 'password': self.password}
-        self.api.post("/sessions", data=data, status_code=201)
-
-        # Comparison necessary to make sure it was updated
-        # email won't be changed, so don't check that
-        user = self.db['users'].find_one({'nethz': self.data['nethz']})
-        keys_except_mail = (key for key in self.data if key != "email")
-        for key in keys_except_mail:
-            self.assertEqual(user[key], self.data[key])
-'''
+                mock_search.assert_called_with(expected_query)
+                mock_create.assert_has_calls([call(1), call(2)])
+                self.assertEqual(result, [3, 3])

--- a/amivapi/tests/test_ldap.py
+++ b/amivapi/tests/test_ldap.py
@@ -1,0 +1,319 @@
+# -*- coding: utf-8 -*-
+#
+# license: AGPLv3, see LICENSE for details. In addition we strongly encourage
+#          you to buy us beer if we meet and you like the software.
+"""LDAP Tests.
+
+Mock the actual ldap responses, since we can only access ldap in the eth
+network which is not usually possible for testing, e.g. on travis.
+
+There is another file, "ldap_integration.py", which can be used to test
+integration with the real ldap. More info there.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from amivapi import ldap
+from amivapi.tests.utils import WebTest, WebTestNoAuth
+
+MOCK_LDAP_DATA = {
+    'testuser1': {
+        'password': 'testpass1',
+
+    },
+    'testuser2': {
+        'password': 'testpass2',
+
+    }
+}
+
+EXPECTED_RESULTS = {
+    'testuser1': {
+
+    },
+    'testuser2': {
+
+    },
+
+}
+
+
+class LdapAuthTest(WebTest):
+    """Tests for LDAP auth."""
+
+    def setUp(self, *args, **kwargs):
+        """Extended setUp, enable LDAP and replace it with a Mock object."""
+        self.test_config['ENABLE_LDAP'] = True
+        self.test_config['LDAP_USER'] = self.test_config['LDAP_PASS'] = "Bla."
+        self.mock_ldap = MagicMock()
+        # When instantiated, it will return the mock object to use in the tests
+        ldap.AuthenticatedLdap = MagicMock(return_value=self.mock_ldap)
+        super(LdapAuthTest, self).setUp(*args, **kwargs)
+
+    def test_ldap_auth(self):
+        """Test that ldap can authenticate a user."""
+        # Auth without ldap doesnt succeed
+        self.mock_ldap.authenticate = MagicMock(return_value=False)
+        self.api.post("/sessions",
+                      data={'username': 'Pablo', 'password': 'p4bl0'},
+                      status_code=401)
+
+        self.mock_ldap.authenticate = MagicMock(return_value=True)
+
+        # We patch sync one to return an existing user
+        # sync one is tested separately
+        sync = 'amivapi.ldap.LdapConnector.sync_one'
+        _id = {'_id': self.new_object('users')["_id"]}
+        with patch(sync, return_value=_id) as patched_sync:
+            # Auth with ldap succeeds
+            self.api.post("/sessions",
+                          data={'username': 'Pablo', 'password': 'p4bl0'},
+                          status_code=201)
+
+            # But we will assert that sync_one is called for successful auth
+            patched_sync.assert_called()
+
+
+class LdapTest(WebTestNoAuth):
+    """Tests for various LDAP functions like sync."""
+
+    def test_escape(self):
+        """Test proper escaping of all characters."""
+        to_escape = "*()\\" + chr(0)
+        expected = r"\\2A\\28\\29\\5C\\00"
+
+        self.assertEqual(ldap._escape(to_escape), expected)
+
+
+    def test_filter(self):
+        """The received LDAP data can look weird. Test that it is filtered."""
+        ldap_data = {
+            'cn': ['pablo'],
+            'swissEduPersonMatriculationNumber': '01234567',
+            'givenName': ['P'],
+            'sn': ['Ablo'],
+            'swissEduPersonGender': '0',
+            'ou': ['VSETH Mitglied', 'D-ITET',
+                   'Informationstechnologie und Elektrotechnik'],
+            'some_random_field': 'abc',
+        }
+
+        with self.app.app_context():
+            filtered = ldap._filter_data(ldap_data)
+
+        expected = {
+            'nethz': 'pablo',
+            'firstname': 'P',
+            'lastname': 'Ablo',
+            'department': 'itet',
+            'membership': 'regular'
+        }
+
+        self.assertEqual(filtered, expected)
+
+'''
+
+# No Pablo in database yet
+        token = self.get_root_token()
+        self.api.get('/users/pablo', status_code=404, token=token)
+
+        # We need to be able to find, authenticate and sync the user
+        ldap_user = {
+            'cn': ['pablo'],
+            'swissEduPersonMatriculationNumber': '01234567',
+            'givenName': ['P'],
+            'sn': ['Ablo'],
+            'swissEduPersonGender': '0',
+            'ou': ['VSETH Mitglied']
+        }
+
+        self.mock_ldap.search = Mock(return_value=[ldap_user])
+
+
+
+
+    def setUp(self, *args, **kwargs):
+        """Extended setUp, replace the ldap in ldap_connector.
+        """
+        self.test_config['ENABLE_LDAP'] = True
+        ldap_connector.ldap = MockLdap()
+
+        super(LdapTest, self).setUp(*args, **kwargs)
+
+
+
+    def test_authenticate_user(self):
+        """Assert authentication is successful."""
+        with self.app.app_context():
+            self.assertTrue(
+                ldap_connector.authenticate_user('testuser1', 'testpass1'))
+
+    def test_find_user(self):
+        """Assert user can be found."""
+        with self.app.app_context():
+            user = ldap_connector.find_user('testuser1')
+            self.assertIsNotNone(user)
+            self.assertEqual(user, self.data)
+
+    def test_find_members(self):
+        """Assert that find_members works.
+
+        - All imported users are members
+        - Our user is in the list.
+        """
+        with self.app.app_context():
+            members = list(ldap_connector.find_members())
+
+            # Assert something is found
+            self.assertTrue(members)
+
+            # Assert only members are imported
+            everyone_is_member = all(member['membership'] == 'regular'
+                                     for member in members)
+
+            self.assertTrue(everyone_is_member)
+
+            # Assert user is found
+            user_data = [member for member in members
+                         if member['nethz'] == self.data['nethz']]
+            self.assertEqual(user_data, self.data)
+
+    def test_compare_and_update(self):
+        """Assert that compare_and_update only changes necessary fields."""
+        fixtures = self.load_fixture({
+            'users': [{'firstname': u'db', 'lastname': u'db'}]})
+        user_id = fixtures[0]['_id']
+
+        with self.app.test_request_context():
+            # Fake db data, only firstname should change
+            fake_db_data = {'_id': user_id,
+                            'firstname': 'db',
+                            'lastname': 'ldap'}
+            fake_ldap_data = {'firstname': 'ldap',
+                              'lastname': 'ldap'}
+
+            ldap_connector.compare_and_update(fake_db_data, fake_ldap_data)
+
+            # Get user from database and compare
+            user = self.db['users'].find_one({'_id': user_id})
+            self.assertEqual(user['firstname'], 'ldap')
+            self.assertEqual(user['lastname'], 'db')
+
+    def test_update_only_upgrades_membership(self):
+        """Assert that the update only changes membership if none."""
+        data_no_change = {'_id': 24 * '0',
+                          'nethz': 'nochange', 'membership': u"honorary"}
+        data_change = {'_id': 24 * '1',
+                       'nethz': 'change', 'membership': u"none"}
+        self.load_fixture({'users': [data_no_change, data_change]})
+
+        with self.app.test_request_context():
+            ldap_data = {'membership': u'regular'}
+
+            ldap_connector.compare_and_update(data_no_change, ldap_data)
+            ldap_connector.compare_and_update(data_change, ldap_data)
+
+            user_no_change = self.db['users'].find_one({'nethz': 'nochange'})
+            user_change = self.db['users'].find_one({'nethz': 'change'})
+            self.assertEqual(user_no_change['membership'],
+                             data_no_change['membership'])
+            self.assertEqual(user_change['membership'],
+                             ldap_data['membership'])
+
+    def test_update_doesnt_change_email(self):
+        """Assert that mail is never changed."""
+        data_no_change = {'nethz': 'nochange', 'email': u"any@thing.ch"}
+        self.load_fixture({'users': [data_no_change]})
+
+        with self.app.test_request_context():
+            ldap_data = {'email': u'some@thing.ch'}
+
+            ldap_connector.compare_and_update(data_no_change, ldap_data)
+
+            user_no_change = self.db['users'].find_one({'nethz': 'nochange'})
+            self.assertEqual(user_no_change['email'],
+                             data_no_change['email'])
+
+    def test_sync_one_import(self):
+        """Assert synchronizing one user works."""
+        with self.app.test_request_context():
+            user = ldap_connector.sync_one(self.data['nethz'])
+
+            # Double check with database
+            check_user = self.db['users'].find_one(
+                {'nethz': self.data['nethz']})
+
+            # Compare by key since self.data doesnt have fields with _
+            for key in self.data:
+                self.assertEqual(user[key], self.data[key])
+                self.assertEqual(check_user[key], self.data[key])
+
+    def test_sync_one_update(self):
+        """Same as before, but the user exists now before ldap sync."""
+        self.load_fixture({'users': [{'nethz': self.data['nethz'],
+                                      'membership': u"none"}]})
+
+        with self.app.test_request_context():
+            user = ldap_connector.sync_one(self.data['nethz'])
+
+            # Double check with database
+            check_user = self.db['users'].find_one(
+                {'nethz': self.data['nethz']})
+
+            # Compare by key since self.data doesnt have fields with
+            # email won't be changed, so don't check that
+            keys_except_mail = (key for key in self.data if key != "email")
+            for key in keys_except_mail:
+                self.assertEqual(user[key], self.data[key])
+                self.assertEqual(check_user[key], self.data[key])
+
+    def test_sync_all(self):
+        """Test sync all imports users by checking the test user."""
+        with self.app.test_request_context():
+            ldap_connector.sync_all()
+
+            # Find test user
+            user = self.db['users'].find_one({'nethz': self.data['nethz']})
+
+            for key in self.data:
+                self.assertEqual(user[key], self.data[key])
+
+    def test_sync_all_update(self):
+        """Same as before, but the user exists now before ldap sync."""
+        self.load_fixture({'users': [{'nethz': self.data['nethz'],
+                                      'membership': u"none"}]})
+
+        with self.app.test_request_context():
+            ldap_connector.sync_all()
+
+            # Find test user
+            user = self.db['users'].find_one({'nethz': self.data['nethz']})
+
+            # email won't be changed, so don't check that
+            keys_except_mail = (key for key in self.data if key != "email")
+            for key in keys_except_mail:
+                self.assertEqual(user[key], self.data[key])
+
+    def test_import_on_login(self):
+        """Test that login imports the user."""
+        data = {'username': self.data['nethz'], 'password': self.password}
+        self.api.post("/sessions", data=data, status_code=201)
+
+        user = self.db['users'].find_one({'nethz': self.data['nethz']})
+        self.assertIsNotNone(user)
+
+    def test_update_on_login(self):
+        """Test login again, but this time the user already exists."""
+        self.load_fixture({'users': [{'nethz': self.data['nethz'],
+                                      'membership': u"none"}]})
+
+        data = {'username': self.data['nethz'], 'password': self.password}
+        self.api.post("/sessions", data=data, status_code=201)
+
+        # Comparison necessary to make sure it was updated
+        # email won't be changed, so don't check that
+        user = self.db['users'].find_one({'nethz': self.data['nethz']})
+        keys_except_mail = (key for key in self.data if key != "email")
+        for key in keys_except_mail:
+            self.assertEqual(user[key], self.data[key])
+'''

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,7 @@ click==6.6
 pytz==2016.7
 ruamel.yaml==0.12.14
 freezegun==0.3.8
+# Mock is only available in the standart lib from 3.3 on
+mock==2.0.0
 # Install amivapi in editable mode to enable command line tools
 -e .


### PR DESCRIPTION
First of all, the structure of ldap.py is now simplified. The class is dropped
and replaced by a few module level functions which are easier to understand.

Next the functions themselves have been rearranged to be easier to test.
Some premature optimization has been removed: The updating of all users
now uses the same function as the one for one user only, since there were not
really noticable performance differences. Again, this simplifies testing.

Speaking of testing: Using mock, all ldap functions are now tested.
There still are some integration tests to verify everything actually works with the
eth ldap.

Finally a few changes in bootstrap, cli and sessions to use the new functions.

After all I am quite hapy with this version now. A few points are still up for improvement and I have added them to ldap.py, but over all the code is much simpler and better tested now, which is nice.

I think I messed up the history a little while rebasing and some commits show up twice and I honestly have no idea how that happened. If anyone knows how this can be fixed please help.