### PR TITLE
Remove trailing = in tokens.

### DIFF
--- a/amivapi/auth/utils.py
+++ b/amivapi/auth/utils.py
@@ -16,4 +16,4 @@ def gen_safe_token():
         str: A random string containing only urlsafe characters.
     """
     return b64encode(urandom(32)).decode("utf-8").replace("+", "-").replace(
-        "/", "_")
+        "/", "_").rstrip("=")


### PR DESCRIPTION
They are unsafe in URLs and add no randomness