### PR TITLE
Correct checked_in default value

### DIFF
--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -275,6 +275,11 @@ eventdomain = {
                 'type': 'boolean',
                 'admin_only': True
             },
+            'checked_in': {
+                'default': None,
+                'type': 'boolean',
+                'admin_only': True
+            },
         }
     }
 }


### PR DESCRIPTION
Corrected the default value for the field `checked_in` in the `eventsignups `schema. This is so to differentiate between someone who checked in, some who did not check in, and the case where nobody cared to check.