### PR TITLE
Fix issue #219

### DIFF
--- a/amivapi/auth/auth.py
+++ b/amivapi/auth/auth.py
@@ -217,7 +217,7 @@ def authenticate(*args):
     # Code copied from Eve's TokenAuth - parse different header formats
     if not token and request.headers.get('Authorization'):
         token = request.headers.get('Authorization').strip()
-        if token.lower().startswith(('token', 'bearer')):
+        if token.lower().startswith(('token', 'bearer')) and ' ' in token:
             token = token.split(' ')[1]
     # End of code copied from Eve
 

--- a/amivapi/auth/auth.py
+++ b/amivapi/auth/auth.py
@@ -217,8 +217,11 @@ def authenticate(*args):
     # Code copied from Eve's TokenAuth - parse different header formats
     if not token and request.headers.get('Authorization'):
         token = request.headers.get('Authorization').strip()
-        if token.lower().startswith(('token', 'bearer')) and ' ' in token:
+        if token.lower().startswith(('token', 'bearer')):
+          if ' ' in token:
             token = token.split(' ')[1]
+          else:
+            token = None
     # End of code copied from Eve
 
     if token:

--- a/amivapi/tests/auth/test_auth.py
+++ b/amivapi/tests/auth/test_auth.py
@@ -247,13 +247,31 @@ class AuthFunctionTest(FakeAuthTest):
         3. A Authorization Header: 'Bearer <token>' (also lowercase)
         4. Authorization header with only 'token'
 
-        Also test that no auth header leads to `g.current_token = None`
+        Also test that no auth header or incomplete auth header leads to `g.current_token = None`
         """
         # No Header
         with self.app.test_request_context():
             authenticate()
             self.assertIsNone(g.current_token)
 
+        # All variations of incomplete headers
+        for header in (
+                "token",
+                "token ",
+                "Token",
+                "Token ",
+                "bearer",
+                "bearer ",
+                "Bearer"
+                "Bearer ",
+                "Basic",
+                "Basic "):
+
+            with self.app.test_request_context(
+                    headers={'Authorization': header}):
+                authenticate()
+                self.assertIsNone(g.current_token)
+            
         token = "ThisIsATokenYeahItIsTheContentDoesntReallyMatter"
         # Encoding dance for py 2/3 compatibility
         b64token = b64encode((token + ":").encode('utf-8')).decode('utf-8')

--- a/amivapi/tests/auth/test_auth.py
+++ b/amivapi/tests/auth/test_auth.py
@@ -263,9 +263,7 @@ class AuthFunctionTest(FakeAuthTest):
                 "bearer",
                 "bearer ",
                 "Bearer"
-                "Bearer ",
-                "Basic",
-                "Basic "):
+                "Bearer "):
 
             with self.app.test_request_context(
                     headers={'Authorization': header}):

--- a/amivapi/tests/auth/test_auth.py
+++ b/amivapi/tests/auth/test_auth.py
@@ -247,7 +247,7 @@ class AuthFunctionTest(FakeAuthTest):
         3. A Authorization Header: 'Bearer <token>' (also lowercase)
         4. Authorization header with only 'token'
 
-        Also test that no auth header or incomplete auth header leads to `g.current_token = None`
+        Also test that no auth header or incomplete auth header lead to `g.current_token = None`
         """
         # No Header
         with self.app.test_request_context():
@@ -271,7 +271,7 @@ class AuthFunctionTest(FakeAuthTest):
                     headers={'Authorization': header}):
                 authenticate()
                 self.assertIsNone(g.current_token)
-            
+
         token = "ThisIsATokenYeahItIsTheContentDoesntReallyMatter"
         # Encoding dance for py 2/3 compatibility
         b64token = b64encode((token + ":").encode('utf-8')).decode('utf-8')

--- a/amivapi/tests/auth/test_auth.py
+++ b/amivapi/tests/auth/test_auth.py
@@ -247,7 +247,8 @@ class AuthFunctionTest(FakeAuthTest):
         3. A Authorization Header: 'Bearer <token>' (also lowercase)
         4. Authorization header with only 'token'
 
-        Also test that no auth header or incomplete auth header lead to `g.current_token = None`
+        Also test that no or incomplete auth header results in
+        `g.current_token = None`
         """
         # No Header
         with self.app.test_request_context():

--- a/amivapi/tests/auth/test_auth.py
+++ b/amivapi/tests/auth/test_auth.py
@@ -255,33 +255,16 @@ class AuthFunctionTest(FakeAuthTest):
             authenticate()
             self.assertIsNone(g.current_token)
 
-        # All variations of incomplete headers
-        for header in (
-                "token",
-                "token ",
-                "Token",
-                "Token ",
-                "bearer",
-                "bearer ",
-                "Bearer"
-                "Bearer "):
-
-            with self.app.test_request_context(
-                    headers={'Authorization': header}):
-                authenticate()
-                self.assertIsNone(g.current_token)
-
         token = "ThisIsATokenYeahItIsTheContentDoesntReallyMatter"
         # Encoding dance for py 2/3 compatibility
         b64token = b64encode((token + ":").encode('utf-8')).decode('utf-8')
 
-        # All header variations
+        # Header variations
         for header in (
                 token,
-                "token " + token,
                 "Token " + token,
-                "bearer " + token,
                 "Bearer " + token,
+                "SomeotherKeyword " + token,
                 "Basic " + b64token):
 
             with self.app.test_request_context(


### PR DESCRIPTION
Prevent the API from crashing when an empty token is provided for authentication.