### PR TITLE
Improve mailing list config handling.

### DIFF
--- a/amivapi/cli.py
+++ b/amivapi/cli.py
@@ -45,13 +45,13 @@ def recreate_mailing_lists(config):
         echo('No directory for mailing lists specified.')
         return
 
-    # Delete exists lists
+    # Delete existing files
     if isdir(directory):
         for filename in listdir(directory):
             if filename.startswith(prefix):
                 remove(join(directory, filename))
 
-    # Create new lists
+    # Create new files
     with app.app_context():
         groups = app.data.driver.db['groups'].find({}, {'_id': 1})
         new_groups(groups)

--- a/amivapi/cli.py
+++ b/amivapi/cli.py
@@ -13,6 +13,7 @@ from amivapi.bootstrap import create_app
 from amivapi.cron import run_scheduled_tasks
 from amivapi import ldap
 from amivapi.settings import DEFAULT_CONFIG_FILENAME, FORWARD_DIR
+from amivapi.groups.mailing_lists import new_groups
 
 
 @group()
@@ -23,6 +24,16 @@ def cli():
 config_option = option("--config",
                        type=Path(exists=True, dir_okay=False, readable=True),
                        help="use specified config file")
+
+
+@cli.command()
+@config_option
+def recreate_forwards(config):
+    """(Re-)create mailing lists for all groups."""
+    app = create_app(config) if config else create_app()
+    with app.app_context():
+        groups = app.data.driver.db['groups'].find({}, {'_id': 1})
+        new_groups(groups)
 
 
 @cli.command()

--- a/amivapi/cli.py
+++ b/amivapi/cli.py
@@ -42,7 +42,7 @@ def recreate_mailing_lists(config):
     prefix = app.config['MAILING_LIST_FILE_PREFIX']
 
     if not directory:
-        echo('No directory for mailing lists specified.')
+        echo('No directory for mailing lists specified in config.')
         return
 
     # Delete existing files

--- a/amivapi/groups/mailing_lists.py
+++ b/amivapi/groups/mailing_lists.py
@@ -24,7 +24,7 @@ def make_files(group_id):
 
     If the file exists it will be overwritten.
 
-    If `STORAGE_DIR` is not set in the config (or empty), no files are created.
+    If `FORWARD_DIR` is not set in the config (or empty), no files are created.
 
     Args:
         group_id (str): The id of the group
@@ -67,7 +67,7 @@ def make_files(group_id):
 def remove_files(addresses):
     """Create several mailing list files
 
-    If `STORAGE_DIR` is not set in the config (or empty), nothing happens.
+    If `FORWARD_DIR` is not set in the config (or empty), nothing happens.
 
     Args:
         addresses (list): email addresses with a forward file to delete

--- a/amivapi/groups/mailing_lists.py
+++ b/amivapi/groups/mailing_lists.py
@@ -24,12 +24,12 @@ def make_files(group_id):
 
     If the file exists it will be overwritten.
 
-    If `FORWARD_DIR` is not set in the config (or empty), no files are created.
+    If `MAILING_LIST_DIR` is not set in the config (or empty), nothing happens.
 
     Args:
         group_id (str): The id of the group
     """
-    if not current_app.config.get('FORWARD_DIR'):
+    if not current_app.config.get('MAILING_LIST_DIR'):
         return
 
     group_objectid = ObjectId(group_id)
@@ -55,38 +55,39 @@ def make_files(group_id):
         # Create all needed forwards
         for listname in group.get('receive_from', []):
             # Check if directory needs to be created
-            forward_path = current_app.config['FORWARD_DIR']
+            forward_path = current_app.config['MAILING_LIST_DIR']
             if not path.isdir(forward_path):
                 makedirs(forward_path)
 
-            with open(_get_filename(listname), 'w') as f:
-                f.write(addresses)
-                f.truncate()  # Needed if old file was bigger
+            with open(_get_filename(listname), 'w') as file:
+                file.write(addresses)
+                file.truncate()  # Needed if old file was bigger
 
 
 def remove_files(addresses):
     """Create several mailing list files
 
-    If `FORWARD_DIR` is not set in the config (or empty), nothing happens.
+    If `MAILING_LIST_DIR` is not set in the config (or empty), nothing happens.
 
     Args:
         addresses (list): email addresses with a forward file to delete
     """
-    if not current_app.config.get('FORWARD_DIR'):
+    if not current_app.config.get('MAILING_LIST_DIR'):
         return
 
     for address in addresses:
         try:
             remove(_get_filename(address))
-        except OSError as e:
+        except OSError as error:
             current_app.logger.error(
-                str(e) + "\nCan not remove forward %s ! It seems the "
+                str(error) + "\nCan not remove forward %s ! It seems the "
                 "forward database is inconsistent!" % address)
 
 
 def _get_filename(email):
     """Generate the filename for a mailinglist for itet mail forwarding."""
-    return path.join(current_app.config['FORWARD_DIR'], '.forward+%s' % email)
+    return path.join(current_app.config['MAILING_LIST_DIR'],
+                     current_app.config['MAILING_LIST_FILE_PREFIX'] + email)
 
 
 # Hooks

--- a/amivapi/groups/mailing_lists.py
+++ b/amivapi/groups/mailing_lists.py
@@ -24,9 +24,14 @@ def make_files(group_id):
 
     If the file exists it will be overwritten.
 
+    If `STORAGE_DIR` is not set in the config (or empty), no files are created.
+
     Args:
         group_id (str): The id of the group
     """
+    if not current_app.config.get('FORWARD_DIR'):
+        return
+
     group_objectid = ObjectId(group_id)
 
     # Get group
@@ -62,9 +67,14 @@ def make_files(group_id):
 def remove_files(addresses):
     """Create several mailing list files
 
+    If `STORAGE_DIR` is not set in the config (or empty), nothing happens.
+
     Args:
         addresses (list): email addresses with a forward file to delete
     """
+    if not current_app.config.get('FORWARD_DIR'):
+        return
+
     for address in addresses:
         try:
             remove(_get_filename(address))

--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -38,8 +38,11 @@ X_HEADERS = ['Authorization', 'Content-Type', 'Cache-Control',
 MONGO_QUERY_BLACKLIST = ['$where']  # default blacklists where and regex queries
 CACHE_CONTROL = 'no-store, must-revalidate'
 
+# Mailing List Files
+MAILING_LIST_DIR = ''  # By default, no forwards are saved
+MAILING_LIST_FILE_PREFIX = '.forward+'
+
 # File Storage
-FORWARD_DIR = ''  # By default, no forwards are saved
 RETURN_MEDIA_AS_BASE64_STRING = False
 RETURN_MEDIA_AS_URL = True
 MEDIA_URL = 'string'  # Very important to match url properly

--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -39,7 +39,7 @@ MONGO_QUERY_BLACKLIST = ['$where']  # default blacklists where and regex queries
 CACHE_CONTROL = 'no-store, must-revalidate'
 
 # File Storage
-FORWARD_DIR = 'amivapi_forwards'
+FORWARD_DIR = ''  # By default, no forwards are saved
 RETURN_MEDIA_AS_BASE64_STRING = False
 RETURN_MEDIA_AS_URL = True
 MEDIA_URL = 'string'  # Very important to match url properly

--- a/amivapi/tests/groups/test_mailing_lists.py
+++ b/amivapi/tests/groups/test_mailing_lists.py
@@ -6,12 +6,27 @@
 """Tests for mailing list files."""
 
 from os.path import isfile, join
+from shutil import rmtree
+from tempfile import mkdtemp
+
 
 from amivapi.tests.utils import WebTestNoAuth
 
 
-class GroupModelTest(WebTestNoAuth):
+class MailingListTest(WebTestNoAuth):
     """Test creation and removal of mailing list files."""
+
+    def setUp(self):
+        """Create a temporary directory for mailing lists."""
+        super(MailingListTest, self).setUp()
+        base_dir = mkdtemp(prefix='amivapi_test')
+        self.test_config['FORWARD_DIR'] = join(base_dir, 'forwards')
+
+    def tearDown(self):
+        """Remove temporary directory."""
+        directory = self.app.config['FORWARD_DIR']
+        rmtree(directory, ignore_errors=True)
+        super(MailingListTest, self).tearDown()
 
     def _full_name(self, name):
         forward_path = self.app.config['FORWARD_DIR']

--- a/amivapi/tests/groups/test_mailing_lists.py
+++ b/amivapi/tests/groups/test_mailing_lists.py
@@ -20,7 +20,7 @@ class MailingListTest(WebTestNoAuth):
         """Create a temporary directory for mailing lists."""
         super(MailingListTest, self).setUp()
         base_dir = mkdtemp(prefix='amivapi_test')
-        self.test_config['MAILING_LIST_DIR'] = join(base_dir, 'lists')
+        self.app.config['MAILING_LIST_DIR'] = join(base_dir, 'lists')
 
     def tearDown(self):
         """Remove temporary directory."""

--- a/amivapi/tests/groups/test_mailing_lists.py
+++ b/amivapi/tests/groups/test_mailing_lists.py
@@ -20,24 +20,25 @@ class MailingListTest(WebTestNoAuth):
         """Create a temporary directory for mailing lists."""
         super(MailingListTest, self).setUp()
         base_dir = mkdtemp(prefix='amivapi_test')
-        self.test_config['FORWARD_DIR'] = join(base_dir, 'forwards')
+        self.test_config['MAILING_LIST_DIR'] = join(base_dir, 'lists')
 
     def tearDown(self):
         """Remove temporary directory."""
-        directory = self.app.config['FORWARD_DIR']
+        directory = self.app.config['MAILING_LIST_DIR']
         rmtree(directory, ignore_errors=True)
         super(MailingListTest, self).tearDown()
 
     def _full_name(self, name):
-        forward_path = self.app.config['FORWARD_DIR']
-        return join(forward_path, '.forward+%s' % name)
+        list_path = self.app.config['MAILING_LIST_DIR']
+        list_prefix = self.app.config['MAILING_LIST_FILE_PREFIX']
+        return join(list_path, list_prefix + name)
 
-    def assertForward(self, name, content):
-        """Assert that the lines in the forward file are correct."""
-        with open(self._full_name(name), 'r') as f:
-            self.assertItemsEqual(content, f.read().split('\n'))
+    def assertFileContent(self, name, content):
+        """Assert that the lines in the mailing list file are correct."""
+        with open(self._full_name(name), 'r') as file:
+            self.assertItemsEqual(content, file.read().split('\n'))
 
-    def assertNoForward(self, name):
+    def assertNoFile(self, name):
         """Assert the file doesnt exist."""
         self.assertFalse(isfile(self._full_name(name)))
 
@@ -51,7 +52,7 @@ class MailingListTest(WebTestNoAuth):
         self.api.post('/groups', data=data, status_code=201)
 
         for name in receive:
-            self.assertForward(name, forward)
+            self.assertFileContent(name, forward)
 
     def test_batch_insert(self):
         """Test creating several groups."""
@@ -62,8 +63,8 @@ class MailingListTest(WebTestNoAuth):
         data = [{'name': 'first', 'receive_from': r1, 'forward_to': f1},
                 {'name': 'second', 'receive_from': r2, 'forward_to': f2}]
         self.api.post('/groups', data=data, status_code=201)
-        self.assertForward(r1[0], f1)
-        self.assertForward(r2[0], f2)
+        self.assertFileContent(r1[0], f1)
+        self.assertFileContent(r2[0], f2)
 
     def _add_base_group(self):
         data = {'name': 'testgroup',
@@ -78,8 +79,8 @@ class MailingListTest(WebTestNoAuth):
         self.api.patch('/groups/' + r['_id'], data={'receive_from': ['r1']},
                        headers={'If-Match': r['_etag']}, status_code=200)
 
-        self.assertNoForward('r2')
-        self.assertForward('r1', ['f1@amiv.ch', 'f2@amiv.ch'])
+        self.assertNoFile('r2')
+        self.assertFileContent('r1', ['f1@amiv.ch', 'f2@amiv.ch'])
 
     def test_change_forward_to(self):
         r = self._add_base_group()
@@ -87,16 +88,16 @@ class MailingListTest(WebTestNoAuth):
                        data={'forward_to': ['new@amiv.ch']},
                        headers={'If-Match': r['_etag']}, status_code=200)
 
-        self.assertForward('r1', ['new@amiv.ch'])
-        self.assertForward('r2', ['new@amiv.ch'])
+        self.assertFileContent('r1', ['new@amiv.ch'])
+        self.assertFileContent('r2', ['new@amiv.ch'])
 
     def test_remove_group(self):
         r = self._add_base_group()
         self.api.delete('/groups/' + r['_id'],
                         headers={'If-Match': r['_etag']}, status_code=204)
 
-        self.assertNoForward('r1')
-        self.assertNoForward('r2')
+        self.assertNoFile('r1')
+        self.assertNoFile('r2')
 
     def _add_user_and_group(self):
         self.load_fixture({
@@ -116,13 +117,13 @@ class MailingListTest(WebTestNoAuth):
                           data={'user': 24 * '0', 'group': 24 * '2'},
                           status_code=201).json
 
-        self.assertForward('a', ['user@amiv.ch', 'b@amiv.ch'])
+        self.assertFileContent('a', ['user@amiv.ch', 'b@amiv.ch'])
 
         self.api.delete('/groupmemberships/' + r['_id'],
                         headers={'If-Match': r['_etag']},
                         status_code=204)
 
-        self.assertForward('a', ['b@amiv.ch'])
+        self.assertFileContent('a', ['b@amiv.ch'])
 
     def test_add_members_batch(self):
         self._add_user_and_group()
@@ -130,8 +131,8 @@ class MailingListTest(WebTestNoAuth):
                 {'user': 24 * '1', 'group': 24 * '2'}]
         self.api.post('/groupmemberships', data=data, status_code=201)
 
-        self.assertForward('a',
-                           ['user@amiv.ch', 'other@amiv.ch', 'b@amiv.ch'])
+        self.assertFileContent('a',
+                               ['user@amiv.ch', 'other@amiv.ch', 'b@amiv.ch'])
 
     def test_member_changes_email(self):
         """Test that the file gets renewed when a member changes his email."""
@@ -143,7 +144,7 @@ class MailingListTest(WebTestNoAuth):
             'groupmemberships': [{'user': 24 * '0', 'group': 24 * '1'}]
         })
 
-        self.assertForward('a', ['user@amiv.ch'])
+        self.assertFileContent('a', ['user@amiv.ch'])
 
         # Patch user
         url = "/users/" + 24 * "0"
@@ -151,4 +152,4 @@ class MailingListTest(WebTestNoAuth):
         self.api.patch(url, headers={'If-Match': etag},
                        data={'email': "new@amiv.ch"}, status_code=200)
 
-        self.assertForward('a', ['new@amiv.ch'])
+        self.assertFileContent('a', ['new@amiv.ch'])

--- a/amivapi/tests/utils.py
+++ b/amivapi/tests/utils.py
@@ -6,10 +6,7 @@
 
 from itertools import count
 import json
-import os
-from shutil import rmtree
 import sys
-from tempfile import mkdtemp
 import unittest
 
 from bson import ObjectId
@@ -93,8 +90,6 @@ class WebTest(unittest.TestCase, FixtureMixin):
     # Test Config overwrites
     test_config = {
         'MONGO_DBNAME': 'test_amivapi',
-        'STORAGE_DIR': '',
-        'FORWARD_DIR': '',
         'API_MAIL': 'api@test.ch',
         'SMTP_SERVER': '',
         'TESTING': True,
@@ -126,11 +121,6 @@ class WebTest(unittest.TestCase, FixtureMixin):
         if sys.version_info >= (3, 2):
             self.assertItemsEqual = self.assertCountEqual
 
-        # create temporary directory for storage
-        base_dir = mkdtemp(prefix='amivapi_test')
-        self.test_config['STORAGE_DIR'] = os.path.join(base_dir, 'storage')
-        self.test_config['FORWARD_DIR'] = os.path.join(base_dir, 'forwards')
-
         # create eve app and test client
         self.app = bootstrap.create_app(**self.test_config)
         self.app.response_class = TestResponse
@@ -149,11 +139,6 @@ class WebTest(unittest.TestCase, FixtureMixin):
         self.connection.drop_database(self.test_config['MONGO_DBNAME'])
         # close database connection
         self.connection.close()
-
-        # remove temporary folders
-        for directory_name in 'STORAGE_DIR', 'FORWARD_DIR':
-            directory = self.app.config[directory_name]
-            rmtree(directory, ignore_errors=True)
 
     # Shortcuts to get a token
     counter = count()


### PR DESCRIPTION
If no forward directory is specified, the api now won't store any forward files.

Furthermore, a CLI command is added to re-create all forward files if needed.