### PR TITLE
Rename `has_zoidberg_share` to `requires_storage` (Resolves #182)

### DIFF
--- a/amivapi/groups/model.py
+++ b/amivapi/groups/model.py
@@ -167,7 +167,7 @@ groupdomain = {
                 'description': 'If true, the group can be seen by all users and'
                 ' they can subscribe themselves.'
             },
-            'has_zoidberg_share': {
+            'requires_storage': {
                 'type': 'boolean',
                 'default': False,
                 'description': 'If the group has a share in the amiv storage.'

--- a/amivapi/tests/groups/test_model.py
+++ b/amivapi/tests/groups/test_model.py
@@ -108,7 +108,7 @@ class GroupModelTest(WebTest):
         user_token = self.get_user_token(user_id)
         mod_token = self.get_user_token(mod_id)
 
-        patch = {'has_zoidberg_share': True}
+        patch = {'requires_storage': True}
         header = {'If-Match': etag}
 
         self.api.patch("/groups/%s" % group_id, data=patch, headers=header,


### PR DESCRIPTION
As of now, the amiv cloud is still in development. We should rename this field as long as it is not used in production.

I urge to rename this field to avoid confusion in the future.