### PR TITLE
Create mailing list files remotely via ssh.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Now it's time to configure AMIVAPI. Create a file `config.py`
 
     # Mailing lists for groups (optional, uncomment if needed)
     # MAILING_LIST_DIR = '/directory/to/store/mailing/list/files/'
+    
+    # Remote mailings list files via ssh (optional)
+    # REMOTE_MAILING_LIST_ADDRESS = 'user@remote.host'
+    # REMOTE_MAILING_LIST_KEYFILE = ''
+    # REMOTE_MAILING_LIST_DIR = './'
 
     # SMTP configuration for mails sent by AMIVAPI (optional)
     # API_MAIL = 'api@amiv.ethz.ch'

--- a/amivapi/cli.py
+++ b/amivapi/cli.py
@@ -12,7 +12,7 @@ from click import argument, echo, group, option, Path
 from amivapi.bootstrap import create_app
 from amivapi.cron import run_scheduled_tasks
 from amivapi import ldap
-from amivapi.groups.mailing_lists import new_groups
+from amivapi.groups.mailing_lists import update_group
 
 
 @group()
@@ -30,9 +30,11 @@ config_option = option("--config",
 def recreate_mailing_lists(config):
     """(Re-)create mailing lists for all groups.
 
-    1. Delete all mailing list files in mailing list directory.
+    1. Delete all mailing list files.
 
-    2. Create new mailing list files for each group in the database.
+    2. Create new mailing list files.
+
+    For every group, we call the update_group function for this
     """
     app = create_app(config_file=config)
     directory = app.config.get('MAILING_LIST_DIR')
@@ -50,8 +52,9 @@ def recreate_mailing_lists(config):
 
     # Create new files
     with app.app_context():
-        groups = app.data.driver.db['groups'].find({}, {'_id': 1})
-        new_groups(groups)
+        groups = app.data.driver.db['groups'].find({})
+        for g in groups:
+            update_group(g, g)  # Use group as update and original
 
 
 @cli.command()

--- a/amivapi/groups/mailing_lists.py
+++ b/amivapi/groups/mailing_lists.py
@@ -9,85 +9,22 @@ Everytime a group changes or a groupmember is added/removed, the group mail
 files will be regenerated.
 (Since we do not get thousands of requests like this per second we don't need
  anything fancy.)
+
+ The files can be created locally or remotely via ssh, to support the current
+ mailing list server solution in place.
+
+ Ssh is probably not the best approach for this, but unfortunately the server
+ does not support any other type of connection.
+ If this changes, this implementation should be updated.
 """
 
 from itertools import chain
 from os import makedirs, path, remove
+from subprocess import Popen, PIPE
 
 from bson import ObjectId
 
 from flask import current_app
-
-
-def make_files(group_id):
-    """Create all mailing lists for a group.
-
-    If the file exists it will be overwritten.
-
-    If `MAILING_LIST_DIR` is not set in the config (or empty), nothing happens.
-
-    Args:
-        group_id (str): The id of the group
-    """
-    if not current_app.config.get('MAILING_LIST_DIR'):
-        return
-
-    group_objectid = ObjectId(group_id)
-
-    # Get group
-    group = current_app.data.driver.db['groups'].find_one(
-        {'_id': group_objectid}, {'receive_from': 1, 'forward_to': 1})
-
-    if group:
-        # Get user mails
-        memberships = current_app.data.driver.db['groupmemberships'].find(
-            {'group': group_objectid}, {'user': 1})
-        user_ids = [membership['user'] for membership in memberships]
-        users = current_app.data.driver.db['users'].find(
-            {'_id': {'$in': user_ids}}, {'email': 1})
-        user_mails = (user['email'] for user in users)
-
-        # The empty string at the chain end ensures we end the data with \n
-        addresses = '\n'.join(chain(group.get('forward_to', []),
-                                    user_mails,
-                                    ''))
-
-        # Create all needed forwards
-        for listname in group.get('receive_from', []):
-            # Check if directory needs to be created
-            forward_path = current_app.config['MAILING_LIST_DIR']
-            if not path.isdir(forward_path):
-                makedirs(forward_path)
-
-            with open(_get_filename(listname), 'w') as file:
-                file.write(addresses)
-                file.truncate()  # Needed if old file was bigger
-
-
-def remove_files(addresses):
-    """Create several mailing list files
-
-    If `MAILING_LIST_DIR` is not set in the config (or empty), nothing happens.
-
-    Args:
-        addresses (list): email addresses with a forward file to delete
-    """
-    if not current_app.config.get('MAILING_LIST_DIR'):
-        return
-
-    for address in addresses:
-        try:
-            remove(_get_filename(address))
-        except OSError as error:
-            current_app.logger.error(
-                str(error) + "\nCan not remove forward %s ! It seems the "
-                "forward database is inconsistent!" % address)
-
-
-def _get_filename(email):
-    """Generate the filename for a mailinglist for itet mail forwarding."""
-    return path.join(current_app.config['MAILING_LIST_DIR'],
-                     current_app.config['MAILING_LIST_FILE_PREFIX'] + email)
 
 
 # Hooks
@@ -100,7 +37,7 @@ def new_groups(groups):
 
 def updated_group(updates, original):
     """Update group mailing lists if any address changes."""
-    # This is just the simplest solution. Could be advanced if needed.
+    # This is just the simplest solution. Could be more advanced if needed.
     if ('receive_from' in updates) or ('forward_to' in updates):
         remove_files(original.get('receive_from', []))
         make_files(original['_id'])
@@ -108,7 +45,6 @@ def updated_group(updates, original):
 
 def removed_group(group):
     """Delete all mailinglist files."""
-    print(group)
     remove_files(group.get('receive_from', []))
 
 
@@ -134,3 +70,159 @@ def updated_user(updates, original):
 
         for membership in memberships:
             make_files(str(membership['group']))
+
+
+# File Handling
+
+def make_files(group_id):
+    """Create all mailing lists for a group.
+
+    If the file exists it will be overwritten.
+    If `MAILING_LIST_DIR` set in config, create a local file.
+    If `REMOTE_MAILING_LIST_ADDRESS` set in config, create remote file.
+
+    Args:
+        group_id (str): The id of the group
+    """
+    # Check if any file will be created, otherwise avoid db access
+    if (current_app.config['MAILING_LIST_DIR'] or
+            current_app.config['REMOTE_MAILING_LIST_ADDRESS']):
+        group_objectid = ObjectId(group_id)
+
+        # Get group, ensure to include mail addresses
+        group = current_app.data.driver.db['groups'].find_one(
+            {'_id': group_objectid}, {'receive_from': 1, 'forward_to': 1})
+
+        if group:
+            # get mail addresses of all users in group
+            memberships = current_app.data.driver.db['groupmemberships'].find(
+                {'group': group_objectid}, {'user': 1})
+            user_ids = [membership['user'] for membership in memberships]
+            users = current_app.data.driver.db['users'].find(
+                {'_id': {'$in': user_ids}}, {'email': 1})
+            user_mails = (user['email'] for user in users)
+
+            # file content: user mails and 'forward_to' entries
+            # The empty string (last arg) ensures that the data ends with '\n'
+            content = '\n'.join(chain(group.get('forward_to', []),
+                                      user_mails,
+                                      ''))
+
+            # A file is required for each 'receive_from' entry
+            for address in group.get('receive_from', []):
+                # Local
+                local_dir = current_app.config['MAILING_LIST_DIR']
+                if local_dir:
+                    # Create directory if needed
+                    if not path.isdir(local_dir):
+                        makedirs(local_dir)
+
+                    with open(_get_local_path(address), 'w') as file:
+                        file.write(content)
+                        file.truncate()  # If old file was larger, cut of rest
+
+                # Remote
+                if current_app.config['REMOTE_MAILING_LIST_ADDRESS']:
+                    ssh_create(address, content)
+
+
+def remove_files(addresses):
+    """Remove several mailing list files.
+
+    If `MAILING_LIST_DIR` set in config, create a local file.
+    If `REMOTE_MAILING_LIST_ADDRESS` set in config, create remote file.
+
+    Args:
+        addresses (list): email addresses with a forward file to delete
+    """
+    for address in addresses:
+        # Local
+        if current_app.config['MAILING_LIST_DIR']:
+            try:
+                remove(_get_local_path(address))
+            except OSError as error:
+                current_app.logger.error(
+                    str(error) + "\nCan not remove mailing list '%s' ! The "
+                    "mailing list database seems to be inconsistent!"
+                    % address)
+
+        # Remote
+        if current_app.config['REMOTE_MAILING_LIST_ADDRESS']:
+            ssh_remove(address)
+
+
+def _get_local_path(email):
+    """Local path for a mailinglist for itet mail forwarding."""
+    return path.join(current_app.config['MAILING_LIST_DIR'],
+                     current_app.config['MAILING_LIST_FILE_PREFIX'] + email)
+
+
+def _get_remote_path(email):
+    """Remote path for a mailinglist for itet mail forwarding."""
+    return path.join(current_app.config['REMOTE_MAILING_LIST_DIR'],
+                     current_app.config['MAILING_LIST_FILE_PREFIX'] + email)
+
+
+# SSH Helpers (in separate functions for easier testing)
+
+def ssh_create(address, content):
+    """Create a file with content remotely over ssh."""
+    # Create dir, then use 'cat - ' to listen to stdin
+    folder = current_app.config['REMOTE_MAILING_LIST_DIR']
+    file = _get_remote_path(address)
+    ssh_command('mkdir -p %s; cat - > %s' % (folder, file), input=content)
+
+
+def ssh_remove(address):
+    """Remove a file remotely over ssh."""
+    path = _get_remote_path(address)
+    try:
+        ssh_command('rm %s' % path)
+    except RuntimeError as e:
+        # File does not exist: log issue, but do not raise exception
+        no_file_error = ("rm: cannot remove '%s': No such file or directory" %
+                         path)
+        if no_file_error in str(e):
+            current_app.logger.error(
+                "Cannot remove remote mailing list '%s' because the file does "
+                "not exist. The mailing list database seems to be"
+                "inconsistent." % address)
+        else:
+            raise e
+
+
+def ssh_command(remote_command, input=None):
+    """Call the given command remotely via ssh with input (if given).
+
+    Popen and communicate are used for compatibility with both python 2 and 3.
+
+    Args:
+        remote_command(Str): Command to execute on remote server
+        input(Str): Input, is sent to remote process via stdin
+
+    Returns:
+        Str: stdout of command
+
+    Raises:
+        RuntimeError: An error with the ssh connection occured.
+    """
+    keyfile = current_app.config.get('REMOTE_MAILING_LIST_KEYFILE')  # optional
+    address = current_app.config['REMOTE_MAILING_LIST_ADDRESS']
+
+    # Construct local ssh command, use -i option if keyfile is specified
+    cmd = (["ssh"] + (['-i', keyfile] if keyfile else []) +
+           [address, remote_command])
+
+    # Open subprocess, initialize pipes for input and errors
+    process = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+
+    # Send input (as bytes) and receive errors (will also be bytes)
+    out, error = process.communicate(input=input.encode() if input else None)
+
+    # Raise RuntimeError if anything went wrong
+    if error:
+        raise RuntimeError("Executing command via ssh failed with error:\n%s"
+                           % error.decode())
+
+    if out:
+        return out.decode()

--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -53,9 +53,12 @@ RETURN_MEDIA_AS_URL = True
 MEDIA_URL = 'string'  # Very important to match url properly
 EXTENDED_MEDIA_INFO = ['name', 'content_type', 'length', 'upload_date']
 
-# Mailing Lists
-MAILING_LIST_DIR = ''  # By default, no forwards are saved
-MAILING_LIST_FILE_PREFIX = '.forward+'
+# Mailing Lists, local and remote options (by default no storage)
+MAILING_LIST_FILE_PREFIX = '.forward+'  # default file name: .forward+groupname
+MAILING_LIST_DIR = None
+REMOTE_MAILING_LIST_ADDRESS = None
+REMOTE_MAILING_LIST_KEYFILE = None
+REMOTE_MAILING_LIST_DIR = './'  # Use home directory on remote by default
 
 # SMTP server defaults
 API_MAIL = 'api@amiv.ethz.ch'


### PR DESCRIPTION
Until now, mailing list files are created locally.
For the mailing lists to actually work, they need to be copied to a remote
server.

This copying is now included in AMIVAPI, which has two main benefits:

- No local files are required anymore, useful for future deployment with docker
- No external copying tool is required to make mailing lists work with amivapi

Unfortunately, the mailing list server supports *only* ssh connections,
therefore we have no other option to transfer the files.

While I do not think this is a very *good* solution, I believe its the *best*
approach we have available.

Closes #239.