### PR TITLE
Switch from uwsgi to bjoern

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,60 @@
+# Docker
+Dockerfile
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Editor backups
+*~
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,47 +1,28 @@
 FROM python:3.6-alpine
 
-# Create user with home directory and no password
+# Create user with home directory and no password and change workdir
 RUN adduser -Dh /api amivapi
-# API will run on port 80
-EXPOSE 80
-# Files will be in /api directory
 WORKDIR /api
+# API will run on port 80
+EXPOSE 8080
 # Environment variable for config, use path for docker secrets as default
 ENV AMIVAPI_CONFIG=/run/secrets/amivapi_config
 
-# Install uwsgi (build tools are required), git is required for install later
-# This would be easier with th uwsgi-python3 packet, but it's somehow not found
-RUN apk add --no-cache --virtual .uwsgi-deps \
-        python3-dev build-base linux-headers &&\
-    apk add --no-cache --virtual .requirements-deps git &&\
-    # We need to keep pcre-dev, otherwise uwsgi won't start
-    apk add --no-cache pcre-dev && \
-    pip install uwsgi
+# Install bjoern and dependencies for install (we need to keep libev)
+RUN apk add --no-cache --virtual .deps \
+        musl-dev python-dev gcc git && \
+    apk add --no-cache libev-dev && \
+    pip install bjoern
 
-# Copy essential files  to /api directory, install requirements
-COPY ./amivapi /api/amivapi
-COPY ./requirements.txt /api/requirements.txt
-COPY ./setup.py /api/setup.py
-COPY ./LICENSE /api/LICENSE
+# Copy files to /api directory, install requirements
+COPY ./ /api
 RUN pip install -r /api/requirements.txt
 
 # Cleanup dependencies
-RUN apk del .uwsgi-deps .requirements-deps
+RUN apk del .deps
 
-# Create a minimal python file that creates an amivapi app
-RUN printf 'from amivapi import create_app\napp = create_app()' > /api/app.py
+# Switch user
+USER amivapi
 
-# Run uwsgi as user amivapi to serve the app on port 80
-CMD ["uwsgi", "--master", \
-# User Setup
-"--uid", "amivapi", "--gid", "amivapi", \
-# Per default uwsgi uses preforking, which pymongo does not like -> disable
-"--lazy-apps", \
-# Port 80 requires permission, use shared-socket to bind before dropping root
-"--shared-socket", "[::]:80", \
-"--http-socket", "=0", \
-# Stop uwsgi if app cannot be started
-"--need-app", \
-# Allow accessing the app at / as well as /amivapi for flexible hosting
-"--manage-script-name", \
-"--mount", "/amivapi=app:app"]
+# Start bjoern
+CMD ["python3", "server.py"]

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ secret:
 docker secret create amivapi_config <path/to/amivapi_config.py>
 
 # Create new API service with secret
+# Map port 80 (host) to 8080 (container)
 docker service create \
-    --name amivapi  -p 80:80 --network backend \
+    --name amivapi  -p 80:8080 --network backend \
     --secret amivapi_config \
     amiveth/amivapi
 ```

--- a/server.py
+++ b/server.py
@@ -1,0 +1,8 @@
+# [bjoern](https://github.com/jonashaag/bjoern) uwsgi server to server app
+# Used to serve amivapi in Docker container.
+
+from amivapi import create_app
+import bjoern
+
+print('Starting bjoern...')
+bjoern.run(create_app(), '0.0.0.0', 8080)

--- a/server.py
+++ b/server.py
@@ -1,8 +1,9 @@
-# [bjoern](https://github.com/jonashaag/bjoern) uwsgi server to server app
-# Used to serve amivapi in Docker container.
+# wsgi server (used in docker container)
+# [bjoern](https://github.com/jonashaag/bjoern) required.
 
 from amivapi import create_app
 import bjoern
 
-print('Starting bjoern...')
-bjoern.run(create_app(), '0.0.0.0', 8080)
+if __name__ == '__main__':
+    print('Starting bjoern on port 8080...', flush=True)
+    bjoern.run(create_app(), '0.0.0.0', 8080)


### PR DESCRIPTION
In the production setup, `uwsgi` was causing troubles by dropping connections
if to many requests occured.
I suspected bad configuration but was not able to fix it.

Searching for a solution, I came across [bjoern](https://github.com/jonashaag/bjoern),
a lightweight wsgi-server based on libev.

bjoern solves our problems:
- no dropped connections anymore
- bonus: smaller image
- bonus: runs with less memory
- bonus: no configuration required

Additionally, a `.dockerignore` is added to clean up the image a little. Essentially it just copies the `.gitignore`