### PR TITLE
WIP: Change membership detection used with LDAP

### DIFF
--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -97,6 +97,14 @@ CONFIRM_EMAIL_TEXT = (
 CONFIRM_TEXT = "Your singup was confirmed!"
 SIGNUP_DELETED_TEXT = "Your signup was removed."
 
+# All department affiliations in ldap (departmentnumber) which are assigned to AMIV (by VSETH)
+LDAP_MEMBER_DEPARTMENTNUMBER_LIST = [
+    u'ETH Student D-ITET',
+    u'ETH Studentin D-ITET',
+    u'ETH Student D-MAVT',
+    u'ETH Studentin D-MAVT'
+]
+
 # All organisational units (ou) in ldap which are assigned to AMIV (by VSETH)
 LDAP_MEMBER_OU_LIST = [
     u'Biomedical Engineering MSc',


### PR DESCRIPTION
Unfortunately, no entries get deleted at the LDAP field `ou` (organizational unit). This leads to wrong detection of membership for students which have changed their field of study to one not assigned to us.

The field `departmentnumber` seems to contain just the currently assigned field(s) of study, which should fix the issue.