### PR TITLE
Bugfix: Missing `departmentNumber` in ldap should not crash the API

### DIFF
--- a/amivapi/ldap.py
+++ b/amivapi/ldap.py
@@ -155,9 +155,12 @@ def _process_data(data):
         u"male" if int(data['swissEduPersonGender']) == 1 else u"female"
 
     # See file docstring for explanation of `deparmentNumber` field
+    # In some rare cases, the departmentNumber field is either empty
+    # or missing -> normalize to empty string
+    department_number = next(iter(data.get('departmentNumber', [])), '')
     department_map = current_app.config['LDAP_DEPARTMENT_MAP'].items()
     department = (dept for phrase, dept in department_map
-                  if phrase in data.get('departmentNumber', []))
+                  if phrase in department_number)
     res['department'] = next(department, None)  # None if no match
 
     # Membership: One of our departments and VSETH member

--- a/amivapi/ldap.py
+++ b/amivapi/ldap.py
@@ -157,7 +157,7 @@ def _process_data(data):
     # See file docstring for explanation of `deparmentNumber` field
     department_map = current_app.config['LDAP_DEPARTMENT_MAP'].items()
     department = (dept for phrase, dept in department_map
-                  if phrase in data['departmentNumber'][0])
+                  if phrase in data.get('departmentNumber', []))
     res['department'] = next(department, None)  # None if no match
 
     # Membership: One of our departments and VSETH member

--- a/amivapi/tests/utils.py
+++ b/amivapi/tests/utils.py
@@ -98,7 +98,7 @@ class WebTest(unittest.TestCase, FixtureMixin):
         'SMTP_SERVER': '',
         'TESTING': True,
         'DEBUG': True,   # This makes eve's error messages more helpful
-        'LDAP_USER': None,  # LDAP test require special treatment
+        'LDAP_USERNAME': None,  # LDAP test require special treatment
         'LDAP_PASSWORD': None,  # LDAP test require special treatment
         'PASSWORD_CONTEXT': CryptContext(
             schemes=["pbkdf2_sha256"],


### PR DESCRIPTION
I was just importing missing users from LDAP and had to discover that the
ISG apparently is not that much into data validation, at least not when it
comes to LDAP.

A few (2, to be precise) users are missing the `departmentNumber` field
we need to determine the department.

In this case, the API should not crash but rather assume that the user
has no department.