### PR TITLE
Fix: Regex for localhost oauth

### DIFF
--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -94,7 +94,7 @@ PASSWORD_CONTEXT = CryptContext(
 # unencrypted connections.
 # An expection to this is `localhost`, which can be registered without
 # https to allow testing of local tools (if required)
-REDIRECT_URI_REGEX = '^((http://)?localhost|https://)[^#]+$'
+REDIRECT_URI_REGEX = '^((http://)?localhost[^#]*|https://[^#]+)$'
 
 # Email sent to external users signing up for events
 CONFIRM_EMAIL_TEXT = (


### PR DESCRIPTION
I cannot into regex.

It was set up to allow whitelisting `localhost` for development, but I only tested it
for `localhost:5000` (since thats what I needed locally) and the settings did not allow just `localhost`.

Fixed now.