### PR TITLE
Make group-moderator embeddable

### DIFF
--- a/amivapi/groups/model.py
+++ b/amivapi/groups/model.py
@@ -133,7 +133,10 @@ groupdomain = {
             },
             'moderator': {
                 'type': 'objectid',
-                'data_relation': {'resource': 'users'},
+                'data_relation': {
+                    'resource': 'users',
+                    'embeddable': True,
+                },
                 'nullable': True,
                 'description': 'ID of a user which can add and remove members.'
             },


### PR DESCRIPTION
As so many other relationships, it makes things easier if the group-moderator is embeddable.