### PR TITLE
Stop non-admins from querying restricted fields.

### DIFF
--- a/amivapi/tests/users/test_security.py
+++ b/amivapi/tests/users/test_security.py
@@ -314,7 +314,6 @@ class UserFieldsTest(utils.WebTest):
 
             for query in (python_query, mongo_query, nested_query):
                 url = '/users?where=%s' % query
-                print(url)
                 # User is not allowed
                 self.api.get(url, token=user_token, status_code=status)
 

--- a/amivapi/tests/users/test_security.py
+++ b/amivapi/tests/users/test_security.py
@@ -295,7 +295,10 @@ class UserFieldsTest(utils.WebTest):
 
     def test_query_restricted_fields(self):
         """Only admins can query restricted fields."""
-        for field in self.RESTRICTED_FIELDS:
+        basic = [(field, 200) for field in self.BASIC_FIELDS]
+        restricted = [(field, 400) for field in self.RESTRICTED_FIELDS]
+
+        for field, status in basic + restricted:
             user_id = str(self.new_object('users')['_id'])
             user_token = self.get_user_token(user_id)
             root_token = self.get_root_token()
@@ -305,7 +308,7 @@ class UserFieldsTest(utils.WebTest):
             mongo_query = json.dumps({field: "something"})
             nested_query = json.dumps({
                 '$or': [
-                    {'$and': [{'field': {'$in': ["something"]}}]}
+                    {'$and': [{field: {'$in': ["something"]}}]}
                 ]
             })
 
@@ -313,7 +316,7 @@ class UserFieldsTest(utils.WebTest):
                 url = '/users?where=%s' % query
                 print(url)
                 # User is not allowed
-                self.api.get(url, token=user_token, status_code=400)
+                self.api.get(url, token=user_token, status_code=status)
 
                 # Admin is allowed
                 self.api.get(url, token=root_token, status_code=200)

--- a/amivapi/users/__init__.py
+++ b/amivapi/users/__init__.py
@@ -13,13 +13,17 @@ from .security import (
     hide_fields,
     project_password_status,
     project_password_status_on_inserted,
-    project_password_status_on_updated
+    project_password_status_on_updated,
+    restrict_filters,
 )
 
 
 def init_app(app):
     """Register resources and blueprints, add hooks and validation."""
     register_domain(app, userdomain)
+
+    # Dynamically restrict filter
+    app.on_pre_GET_users += restrict_filters
 
     # project_password_status must be before hide_fields
     app.on_fetched_item_users += project_password_status

--- a/amivapi/users/security.py
+++ b/amivapi/users/security.py
@@ -105,6 +105,22 @@ def hide_fields(response):
                     item.pop(key)
 
 
+def restrict_filters(*_):
+    """If the user is not an admin, restrict the query filters.
+
+    Changing the config modifies subsequent requests, so we need to set
+    it explicitly for each request.
+    """
+    userdomain = current_app.config['DOMAIN']['users']
+    if not (g.get('resource_admin') or g.get('resource_admin_readonly')):
+        userdomain['allowed_filters'] = [
+            '_id', '_etag', '_updated', '_created', '_links'
+            'firstname', 'lastname', 'nethz',
+        ]
+    else:
+        userdomain['allowed_filters'] = ['*']
+
+
 # Project password status
 
 def project_password_status(response):

--- a/amivapi/users/security.py
+++ b/amivapi/users/security.py
@@ -114,7 +114,7 @@ def restrict_filters(*_):
     userdomain = current_app.config['DOMAIN']['users']
     if not (g.get('resource_admin') or g.get('resource_admin_readonly')):
         userdomain['allowed_filters'] = [
-            '_id', '_etag', '_updated', '_created', '_links'
+            '_id', '_etag', '_updated', '_created', '_links',
             'firstname', 'lastname', 'nethz',
         ]
     else:


### PR DESCRIPTION
Fields like legi number are hidden from non-admin users.
Nevertheless, it was possible to query for those fields, e.g. for a
particular legi number, which will only return a single result.

And even if the legi number is hidden, since it is unique it can be
matched to its user without problem.

Changes:
- Eve already allows restricting query parmeters, which is now done
  dynamically for user requests
- Test included