### PR TITLE
Allow session lookup via token.

### DIFF
--- a/amivapi/auth/sessions.py
+++ b/amivapi/auth/sessions.py
@@ -62,6 +62,9 @@ sessiondomain = {
         'resource_methods': ['GET', 'POST'],
         'item_methods': ['GET', 'DELETE'],
 
+        # Allow GET requests with token, i.e. GET /sessions/<token>
+        'additional_lookup': {'field': 'token', 'url': 'string'},
+
         'schema': {
             'username': {
                 'type': 'string',

--- a/amivapi/tests/auth/test_sessions.py
+++ b/amivapi/tests/auth/test_sessions.py
@@ -94,6 +94,14 @@ class AuthentificationTest(WebTest):
         self.assertNotIn(other_session['_id'],
                          ids)
 
+    def test_get_session_by_token(self):
+        """Test accesing session via its token."""
+        user = self.new_object('users', password=u"something")
+        token = self.new_object('sessions', username=str(user['_id']),
+                                password=u"something")['token']
+
+        self.api.get('/sessions/%s' % token, token=token, status_code=200)
+
     def test_no_public_get(self):
         """Test that there is no public reading of sessions."""
         # Create a sess

--- a/amivapi/tests/auth/test_sessions.py
+++ b/amivapi/tests/auth/test_sessions.py
@@ -96,9 +96,8 @@ class AuthentificationTest(WebTest):
 
     def test_get_session_by_token(self):
         """Test accesing session via its token."""
-        user = self.new_object('users', password=u"something")
-        token = self.new_object('sessions', username=str(user['_id']),
-                                password=u"something")['token']
+        # Create a session (with a generic user id)
+        token = self.get_user_token("0"*24)
 
         self.api.get('/sessions/%s' % token, token=token, status_code=200)
 


### PR DESCRIPTION
For most OAuth usecases, accessing tools will have the token and might need to verify whether the session still exists.

This change is intended to make the process even simpler, by allowing requests of the form `GET /sessions/<token>`.