### PR TITLE
specify version of eve-swagger

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 eve==0.7.4
--e git+https://github.com/hermannsblum/eve-swagger.git#egg=Eve_Swagger
+-e git+https://github.com/hermannsblum/eve-swagger.git@5c9cf066ffa72712f9018a3eb0c5142f7733d8cc#egg=Eve_Swagger
 -e git+https://github.com/NotSpecial/nethz.git@1d3004081c3618f1f41463476a847b0bddd6d91a#egg=nethz
 Flask==0.10.1
 passlib==1.6.5


### PR DESCRIPTION
to make sure that changes to the eve-swagger we use do not crash production systems, changes in eve-swagger should always require an update of the requirements and therefore at least a CI test.