### PR TITLE
increase minimum price for event to 1

### DIFF
--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -66,7 +66,7 @@ eventdomain = {
                 'type': 'string'
             },
             'price': {
-                'min': 0,
+                'min': 1,
                 'nullable': True,
                 'type': 'integer',
                 'description': 'Price of the event as Integer in Rappen.'


### PR DESCRIPTION
There are 3 different states which all describe that an event has no price:

* the price field in the event is not set
* the price field in the event is set to `null`
* the price field in the event is set to `0`

In order to reduce confusion, I propose to set the minimum value of the event price to `1`, thus removing the third option above. The first to options are pretty standard for all fields in our api, so they seem a reasonable choice.