### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ eve==0.7.4
 -e git+https://github.com/hermannsblum/eve-swagger.git@5c9cf066ffa72712f9018a3eb0c5142f7733d8cc#egg=Eve_Swagger
 -e git+https://github.com/NotSpecial/nethz.git@1d3004081c3618f1f41463476a847b0bddd6d91a#egg=nethz
 Flask==0.10.1
+# Because of issues with Flask-PyMongo 2.0.0. See https://github.com/pyeve/eve/issues/1172.
+Flask-PyMongo==0.5.2
 passlib==1.6.5
 jsonschema==2.5.1
 click==6.6


### PR DESCRIPTION
As there are currently issues with Flask-PyMongo 2.0.0, add a explicit dependency for Flask-PyMongo 0.5.2.
See pyeve/eve#1172.