### PR TITLE
Set minlength for password

### DIFF
--- a/amivapi/tests/auth/test_oauth.py
+++ b/amivapi/tests/auth/test_oauth.py
@@ -94,7 +94,7 @@ class OAuthTest(WebTest):
 
     def test_login(self):
         """Test that a user can login with username and password."""
-        self.new_object('users', nethz='testuser', password='pass')
+        self.new_object('users', nethz='testuser', password='password')
 
         login_page = self.api.get(
             '/oauth?'
@@ -116,7 +116,7 @@ class OAuthTest(WebTest):
             '&state=xyz',
             data={
                 'username': 'testuser',
-                'password': 'pass'
+                'password': 'password'
             },
             headers={'content-type': 'application/x-www-form-urlencoded'},
             status_code=302)
@@ -139,7 +139,7 @@ class OAuthTest(WebTest):
 
     def test_login_wrong_data(self):
         """Test that wrong credentials lead back to oauth page."""
-        self.new_object('users', nethz='testuser', password='pass')
+        self.new_object('users', nethz='testuser', password='password')
 
         # Simulate sending the login form
         self.api.post(
@@ -163,7 +163,7 @@ class OAuthTest(WebTest):
             '&state=xyz',
             data={
                 'username': 'notuser',
-                'password': 'pass'
+                'password': 'password'
             },
             headers={'content-type': 'application/x-www-form-urlencoded'},
             status_code=200)  # No redirect
@@ -183,7 +183,7 @@ class OAuthTest(WebTest):
 
     def test_remember(self):
         """Test that the token is saved as cookie if requested."""
-        self.new_object('users', nethz='testuser', password='pass')
+        self.new_object('users', nethz='testuser', password='password')
 
         # By default, the token is not remembered
         response = self.api.post(
@@ -194,7 +194,7 @@ class OAuthTest(WebTest):
             '&state=xyz',
             data={
                 'username': 'testuser',
-                'password': 'pass',
+                'password': 'password',
             },
             headers={'content-type': 'application/x-www-form-urlencoded'},
             status_code=302)  # Expect redirect (successful auth)
@@ -210,7 +210,7 @@ class OAuthTest(WebTest):
             '&state=xyz',
             data={
                 'username': 'testuser',
-                'password': 'pass',
+                'password': 'password',
                 'remember': 'remember',
             },
             headers={'content-type': 'application/x-www-form-urlencoded'},

--- a/amivapi/tests/auth/test_session_expiry.py
+++ b/amivapi/tests/auth/test_session_expiry.py
@@ -16,9 +16,9 @@ from amivapi.tests.utils import WebTest
 class TestSessionExpiry(WebTest):
     def test_session_expiry(self):
         with self.app.app_context(), freeze_time() as frozen_time:
-            self.new_object("users", nethz="pablo", password="pass")
+            self.new_object("users", nethz="pablo", password="password")
             self.api.post('/sessions',
-                          data={"username": "pablo", "password": "pass"},
+                          data={"username": "pablo", "password": "password"},
                           status_code=201)
 
             frozen_time.tick(delta=self.app.config['SESSION_TIMEOUT'] -

--- a/amivapi/tests/users/test_security.py
+++ b/amivapi/tests/users/test_security.py
@@ -219,7 +219,7 @@ class UserFieldsTest(utils.WebTest):
                               set(self.BASIC_FIELDS) - set(['_links']))
 
     def test_password_status(self):
-        user = self.new_object('users', password='abc')
+        user = self.new_object('users', password='abcdefg')
         user_no_pass = self.new_object('users', password=None)
 
         root_token = self.get_root_token()

--- a/amivapi/users/model.py
+++ b/amivapi/users/model.py
@@ -96,6 +96,7 @@ userdomain = {
             # Fields the user can modify himself
             'password': {
                 'type': 'string',
+                'minlength': 7,
                 'maxlength': 100,
                 'empty': False,
                 'nullable': True,


### PR DESCRIPTION
Implements the minimal password policy discussed in issue #234 .

Resolves #234.