### PR TITLE
Add write restrictions for eventsignups

### DIFF
--- a/amivapi/events/authorization.py
+++ b/amivapi/events/authorization.py
@@ -5,7 +5,7 @@
 """Authorization for events and eventsignups resources"""
 
 from flask import g, current_app
-from datetime import timezone, datetime as dt
+from datetime import timezone as tz, datetime as dt
 from amivapi.auth import AmivTokenAuth
 
 
@@ -24,8 +24,10 @@ class EventSignupAuth(AmivTokenAuth):
             lookup = {current_app.config['ID_FIELD']: item['event']}
             event = current_app.data.find_one('events', None, **lookup)
 
-        return event['time_register_start'].replace(tzinfo=timezone.utc) <= dt.utcnow()
-            <= event['time_register_end'].replace(tzinfo=timezone.utc)
+        time_register_start = event['time_register_start'].replace(tzinfo=tz.utc)
+        time_register_end = event['time_register_end'].replace(tzinfo=tz.utc)
+
+        return time_register_start <= dt.utcnow() <= time_register_end
 
     def has_resource_write_permission(self, user_id):
         """Anyone can sign up. Further requirements are enforced with validators

--- a/amivapi/events/authorization.py
+++ b/amivapi/events/authorization.py
@@ -5,7 +5,7 @@
 """Authorization for events and eventsignups resources"""
 
 from flask import g, current_app
-from datetime import datetime, timedelta, timezone
+from datetime import datetime as dt
 from amivapi.auth import AmivTokenAuth
 
 
@@ -23,12 +23,8 @@ class EventSignupAuth(AmivTokenAuth):
             # Event is not embedded, get the event first
             lookup = {current_app.config['ID_FIELD']: item['event']}
             event = current_app.data.find_one('events', None, **lookup)
-        time_now = datetime.now(timezone.utc)
 
-        if time_now - event['time_register_start'] > timedelta(seconds=0) and \
-           time_now - event['time_register_end'] < timedelta(seconds=0):
-            return True
-        return False
+        return event['time_register_start'] <= dt.utcnow() <= event['time_register_end']
 
     def has_resource_write_permission(self, user_id):
         """Anyone can sign up. Further requirements are enforced with validators

--- a/amivapi/events/authorization.py
+++ b/amivapi/events/authorization.py
@@ -5,7 +5,7 @@
 """Authorization for events and eventsignups resources"""
 
 from flask import g, current_app
-from datetime import timezone as tz, datetime as dt
+from datetime import datetime as dt
 from amivapi.auth import AmivTokenAuth
 
 
@@ -24,10 +24,10 @@ class EventSignupAuth(AmivTokenAuth):
             lookup = {current_app.config['ID_FIELD']: item['event']}
             event = current_app.data.find_one('events', None, **lookup)
 
-        time_register_start = event['time_register_start']
-        time_register_end = event['time_register_end']
+        time_register_start = event['time_register_start'].replace(tzinfo=None)
+        time_register_end = event['time_register_end'].replace(tzinfo=None)
 
-        return time_register_start <= dt.now() <= time_register_end
+        return time_register_start <= dt.utcnow() <= time_register_end
 
     def has_resource_write_permission(self, user_id):
         """Anyone can sign up. Further requirements are enforced with validators

--- a/amivapi/events/authorization.py
+++ b/amivapi/events/authorization.py
@@ -5,7 +5,7 @@
 """Authorization for events and eventsignups resources"""
 
 from flask import g, current_app
-from datetime import datetime as dt
+from datetime import timezone, datetime as dt
 from amivapi.auth import AmivTokenAuth
 
 
@@ -24,7 +24,8 @@ class EventSignupAuth(AmivTokenAuth):
             lookup = {current_app.config['ID_FIELD']: item['event']}
             event = current_app.data.find_one('events', None, **lookup)
 
-        return event['time_register_start'] <= dt.utcnow() <= event['time_register_end']
+        return event['time_register_start'].replace(tzinfo=timezone.utc) <= dt.utcnow()
+            <= event['time_register_end'].replace(tzinfo=timezone.utc)
 
     def has_resource_write_permission(self, user_id):
         """Anyone can sign up. Further requirements are enforced with validators

--- a/amivapi/events/authorization.py
+++ b/amivapi/events/authorization.py
@@ -11,12 +11,14 @@ from amivapi.auth import AmivTokenAuth
 
 class EventSignupAuth(AmivTokenAuth):
     def create_user_lookup_filter(self, user_id):
-        """Make only own signups visible"""
+        """Users can see their own signups."""
         return {'user': user_id}
 
     def has_item_write_permission(self, user_id, item):
-        """Users can only see their own signups. They may change their own
-        signups only within the registration window of the event."""
+        """Users can modify their signups within the registration window.
+        
+        Signups of other users are not visible and thus cannot be changed.
+        """
         if isinstance(item['event'], dict):
             event = item['event']
         else:

--- a/amivapi/events/authorization.py
+++ b/amivapi/events/authorization.py
@@ -24,6 +24,7 @@ class EventSignupAuth(AmivTokenAuth):
             lookup = {current_app.config['ID_FIELD']: item['event']}
             event = current_app.data.find_one('events', None, **lookup)
 
+        # Remove tzinfo to compare to utcnow (API only accepts UTC anyways)
         time_register_start = event['time_register_start'].replace(tzinfo=None)
         time_register_end = event['time_register_end'].replace(tzinfo=None)
 

--- a/amivapi/events/authorization.py
+++ b/amivapi/events/authorization.py
@@ -24,10 +24,10 @@ class EventSignupAuth(AmivTokenAuth):
             lookup = {current_app.config['ID_FIELD']: item['event']}
             event = current_app.data.find_one('events', None, **lookup)
 
-        time_register_start = event['time_register_start'].replace(tzinfo=tz.utc)
-        time_register_end = event['time_register_end'].replace(tzinfo=tz.utc)
+        time_register_start = event['time_register_start']
+        time_register_end = event['time_register_end']
 
-        return time_register_start <= dt.utcnow() <= time_register_end
+        return time_register_start <= dt.now() <= time_register_end
 
     def has_resource_write_permission(self, user_id):
         """Anyone can sign up. Further requirements are enforced with validators

--- a/amivapi/events/authorization.py
+++ b/amivapi/events/authorization.py
@@ -16,7 +16,7 @@ class EventSignupAuth(AmivTokenAuth):
 
     def has_item_write_permission(self, user_id, item):
         """Users can modify their signups within the registration window.
-        
+
         Signups of other users are not visible and thus cannot be changed.
         """
         if isinstance(item['event'], dict):


### PR DESCRIPTION
Allows write access to `/eventsignups` for non-admins only within the registration window.
Admins can write to the resource at all time.

Write access means `POST`, `PATCH` and `DELETE`.

Resolves #240.