### PR TITLE
Eve08

### DIFF
--- a/amivapi/auth/apikeys.py
+++ b/amivapi/auth/apikeys.py
@@ -79,8 +79,8 @@ apikeydomain = {
             },
             'permissions': {
                 'type': 'dict',
-                'propertyschema': {'type': 'string',
-                                   'api_resources': True},
+                'keyschema': {'type': 'string',
+                              'api_resources': True},
                 'valueschema': {'type': 'string',
                                 'allowed': ['read', 'readwrite']},
                 'description': 'Permissions the apikey grants. '

--- a/amivapi/cron.py
+++ b/amivapi/cron.py
@@ -133,8 +133,8 @@ def schedule_once_soon(func, *args):
     """ Schedules a function to be run as soon as the scheduler is run the next
     time. Also check, that it is not already scheduled to be run first.
     """
-    if current_app.data.driver.db['scheduled_tasks'].find(
-            {'function': func_str(func)}).count() != 0:
+    if current_app.data.driver.db['scheduled_tasks'].count_documents(
+            {'function': func_str(func)}) != 0:
         return
     schedule_task(datetime.utcnow(), func, *args)
 

--- a/amivapi/documentation.py
+++ b/amivapi/documentation.py
@@ -42,7 +42,11 @@ class DocValidator(object):
     """
 
     def _validate_description(*args):
-        """Do nothing."""
+        """Do nothing.
+
+        The rule's arguments are validated against this schema:
+        {'type': 'string'}
+        """
 
 
 def init_app(app):

--- a/amivapi/events/authorization.py
+++ b/amivapi/events/authorization.py
@@ -41,8 +41,11 @@ class EventAuthValidator(object):
 
         Args:
             enabled (bool): validates nothing if set to false
-            field (string): field name.
-            value: field value.
+            field (string): field name
+            value: field value
+
+        The rule's arguments are validated against this schema:
+        {'type': 'boolean'}
         """
         if enabled:
             if g.resource_admin or value is None:

--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -241,8 +241,8 @@ eventdomain = {
                 # Cerberus <= 1.2: Causes problems with `None` values, which
                 # should be treated as missing fields, which is not yet
                 # possible, causing problems if `None` already exists in db
-                #'required': True,
-                #'excludes': ['email']
+                # 'required': True,
+                # 'excludes': ['email']
             },
             'additional_fields': {
                 'nullable': True,
@@ -265,8 +265,8 @@ eventdomain = {
 
                 # This creates a presence XOR with user
                 # see above
-                #'required': True,
-                #'excludes': ['user']
+                # 'required': True,
+                # 'excludes': ['user']
             },
             'confirmed': {
                 'type': 'boolean',

--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -169,7 +169,8 @@ eventdomain = {
             },
             'additional_fields': {
                 'nullable': True,
-                'type': 'json_schema_object',
+                'type': 'string',
+                'json_schema': True,
                 'only_if_not_null': 'spots',
                 'description': 'must be provided in form of a JSON-Schema. You'
                 'can add here fields you want to know from people signing up '
@@ -182,7 +183,6 @@ eventdomain = {
             'allow_email_signup': {
                 'nullable': False,
                 'type': 'boolean',
-                'default': False,
                 'only_if_not_null': 'spots',
                 'description': 'If False, only AMIV-Members can sign up for '
                 'this event'
@@ -238,12 +238,16 @@ eventdomain = {
                 'description': 'Provide either user or email.',
 
                 # This creates a presence XOR with email
-                'required': True,
-                'excludes': ['email']
+                # Cerberus <= 1.2: Causes problems with `None` values, which
+                # should be treated as missing fields, which is not yet
+                # possible, causing problems if `None` already exists in db
+                #'required': True,
+                #'excludes': ['email']
             },
             'additional_fields': {
                 'nullable': True,
-                'type': 'json_event_field',
+                'type': 'string',
+                'json_event_field': True,
                 'description': "Data-schema depends on 'additional_fields' "
                 "from the mapped event. Please provide in json-format."
             },
@@ -260,8 +264,9 @@ eventdomain = {
                 ' their email here.',
 
                 # This creates a presence XOR with user
-                'required': True,
-                'excludes': ['user']
+                # see above
+                #'required': True,
+                #'excludes': ['user']
             },
             'confirmed': {
                 'type': 'boolean',
@@ -273,6 +278,7 @@ eventdomain = {
             },
             'checked_in': {
                 'default': None,
+                'nullable': True,
                 'type': 'boolean',
                 'admin_only': True
             },

--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -235,13 +235,11 @@ eventdomain = {
                 'type': 'objectid',
                 'nullable': False,
                 'unique_combination': ['event'],
-                'description': 'Provide either user or email.'
+                'description': 'Provide either user or email.',
 
                 # This creates a presence XOR with email
-                # TODO: This needs cerberus > 1.0.1
-                # enable as soon as eve supports it
-                # 'required': True,
-                # 'excludes': ['email']
+                'required': True,
+                'excludes': ['email']
             },
             'additional_fields': {
                 'nullable': True,
@@ -259,13 +257,11 @@ eventdomain = {
                 'unique_combination': ['event'],
                 'description': 'For registered users, this is just a projection'
                 ' of your general email-address. External users need to provide'
-                ' their email here.'
+                ' their email here.',
 
                 # This creates a presence XOR with user
-                # TODO: This needs cerberus > 1.0.1
-                # enable as soon as eve supports it
-                # 'required': True,
-                # 'excludes': ['user']
+                'required': True,
+                'excludes': ['user']
             },
             'confirmed': {
                 'type': 'boolean',

--- a/amivapi/events/validation.py
+++ b/amivapi/events/validation.py
@@ -8,7 +8,7 @@ from datetime import datetime
 import json
 
 from flask import current_app, g, request
-from jsonschema import Draft4Validator, SchemaError, ValidationError
+from jsonschema import Draft4Validator, SchemaError
 import pytz
 
 
@@ -33,7 +33,7 @@ class EventValidator(object):
 
         try:
             data = json.loads(value) if value else {}  # Do not crash if ''
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as e:
             self._error(field,
                         "Must be json, parsing failed with exception: %s" % e)
 
@@ -183,7 +183,6 @@ class EventValidator(object):
                                     "'%s' is required to be set to '%s'"
                                     % (key, val))
 
-
                 # now check if it is entirely valid jsonschema
                 validator = Draft4Validator(json_data)
                 # by default, jsonschema specification allows unknown properties
@@ -195,8 +194,6 @@ class EventValidator(object):
                 except SchemaError as error:
                     self._error(field, "does not contain a valid schema: %s"
                                 % error)
-
-
 
     # Eve doesn't handle time zones properly. Its always UTC but sometimes
     # the timezone is included, sometimes it isn't.

--- a/amivapi/events/validation.py
+++ b/amivapi/events/validation.py
@@ -8,14 +8,14 @@ from datetime import datetime
 import json
 
 from flask import current_app, g, request
-from jsonschema import Draft4Validator, SchemaError
+from jsonschema import Draft4Validator, SchemaError, ValidationError
 import pytz
 
 
 class EventValidator(object):
     """Custom Validator for event validation rules."""
 
-    def _validate_type_json_event_field(self, field, value):
+    def _validate_json_event_field(self, enabled, field, value):
         """Validate data in json format with event data.
 
         1.  Is it JSON?
@@ -23,28 +23,30 @@ class EventValidator(object):
         3.  Validate schema and get all errors with prefix 'additional_fields:'
 
         Args:
-            field (string): field name.
-            value: field value.
+            value: field value
+
+        The rule's arguments are validated against this schema:
+        {'type': 'boolean'}
         """
+        if not enabled:
+            return
+
         try:
-            if value:
-                data = json.loads(value)
-            else:
-                data = {}  # Do not crash if ''
-        except Exception as e:
-            self._error(field, "Must be json, parsing failed with exception: %s"
-                        % str(e))
+            data = json.loads(value) if value else {}  # Do not crash if ''
+        except json.JSONDecodeError:
+            self._error(field,
+                        "Must be json, parsing failed with exception: %s" % e)
 
         id_field = current_app.config['ID_FIELD']
         # At this point we have valid JSON, check for event now.
         # If PATCH, then event_id will not be provided, we have to find it
         if request.method == 'PATCH':
-            lookup = {id_field: self._original_document['event']}
+            lookup = {id_field: self.persisted_document['event']}
         elif 'event' in self.document:
             lookup = {id_field: self.document['event']}
         else:
-            # No event provided, the required validator of the event field
-            # will complain.
+            # No event provided, the `required` validator of the event field
+            # will complain, but we can't continue here
             return
 
         event = current_app.data.find_one('events', None, **lookup)
@@ -53,13 +55,11 @@ class EventValidator(object):
         # json schemas can be written to the database
         if event is not None:
             schema = json.loads(event['additional_fields'])
-            v = Draft4Validator(schema)  # Create a new validator
+            validator = Draft4Validator(schema)
 
             # search for errors and move them into main validator
-            for error in v.iter_errors(data):
+            for error in validator.iter_errors(data):
                 self._error(field, error.message)
-
-        # if event id is not valid another validator will fail anyway
 
     def _validate_signup_requirements(self, signup_possible, field, event_id):
         """Validate if signup requirements are met.
@@ -78,8 +78,11 @@ class EventValidator(object):
 
         Args:
             singup_possible (bool); validates nothing if set to false
-            field (string): field name.
-            value: field value.
+            field (string): field name
+            value: field value
+
+        The rule's arguments are validated against this schema:
+        {'type': 'boolean'}
         """
         if signup_possible:
             # We can assume event_id is valid, as the type validator will abort
@@ -106,10 +109,11 @@ class EventValidator(object):
             # so correct error messages are produced
             if (event.get('additional_fields') and
                     ('additional_fields' not in self.document.keys())):
-                self._validate_type_json_event_field('additional_fields',
-                                                     None)
+                self._validate_json_event_field(True,
+                                                'additional_fields',
+                                                '')
 
-    def _validate_email_signup_must_be_allowed(self, enabled, field, value):
+    def _validate_email_signup_must_be_allowed(self, enabled, field, _):
         """Validation for an event field in eventsignups.
 
         Validates if the event allows self enrollment.
@@ -118,8 +122,11 @@ class EventValidator(object):
 
         Args:
             enabled (bool): validates nothing if set to false
-            field (string): field name.
-            value: field value.
+            field (string): field name
+            value: field value
+
+        The rule's arguments are validated against this schema:
+        {'type': 'boolean'}
         """
         if enabled:
             # Get event
@@ -138,68 +145,84 @@ class EventValidator(object):
     General purpose validators
     """
 
-    def _validate_type_json_schema_object(self, field, value):
-        """Validate a cerberus schema saved as JSON.
+    def _validate_json_schema(self, enabled, field, value):
+        """Validate a json schema[1] string.
 
-        1.  Is it JSON?
+        1.  Is the string valid JSON?
         2.  Does it satisfy our restrictions for jsonschemas?
         3.  Is it a valid json-schema?
 
         Args:
-            field (string): field name.
-            value: field value.
+            value: field value
+
+        1: https://json-schema.org
+
+        The rule's arguments are validated against this schema:
+        {'type': 'boolean'}
         """
-        try:
-            json_data = json.loads(value)
-        except Exception as e:
-            self._error(field, "Must be json, parsing failed with exception: %s"
-                        % str(e))
-        else:
-            # validate if these fields are included exactly as given
-            # (we, e.g., always require objects so UI can rely on this)
-            enforced_fields = {
-                '$schema': 'http://json-schema.org/draft-04/schema#',
-                'type': 'object',
-                'additionalProperties': False
-            }
-
-            for key, value in enforced_fields.items():
-                if key not in json_data or json_data[key] != value:
-                    self._error(field,
-                                "'{key}' is required to be set to '{value}'"
-                                .format(key=key, value=value))
-
+        if enabled:
             try:
+                json_data = json.loads(value)
+            except json.JSONDecodeError as error:
+                self._error(field,
+                            "Invalid json, parsing failed with exception: %s"
+                            % error)
+
+            else:
+                # validate if these fields are included exactly as given
+                # (we, e.g., always require objects so UI can rely on this)
+                enforced_fields = {
+                    '$schema': 'http://json-schema.org/draft-04/schema#',
+                    'type': 'object',
+                    'additionalProperties': False
+                }
+
+                for key, val in enforced_fields.items():
+                    if key not in json_data or json_data[key] != val:
+                        self._error(field,
+                                    "'%s' is required to be set to '%s'"
+                                    % (key, val))
+
+
                 # now check if it is entirely valid jsonschema
-                v = Draft4Validator(json_data)
+                validator = Draft4Validator(json_data)
                 # by default, jsonschema specification allows unknown properties
                 # We do not allow these.
-                v.META_SCHEMA['additionalProperties'] = False
-                v.check_schema(json_data)
-            except SchemaError as e:
-                self._error(field, "does not contain a valid schema: %s"
-                            % str(e))
+                validator.META_SCHEMA['additionalProperties'] = False
+
+                try:
+                    validator.check_schema(json_data)
+                except SchemaError as error:
+                    self._error(field, "does not contain a valid schema: %s"
+                                % error)
+
+
 
     # Eve doesn't handle time zones properly. Its always UTC but sometimes
     # the timezone is included, sometimes it isn't.
 
     def _get_time(self, fieldname):
-        """Retrieve time field from document or _original_document."""
+        """Retrieve time field from document or original document."""
         # Try to pick the value from document first, fall back to original
         time = self.document.get(fieldname)
         if time is None:
-            time = (self._original_document[fieldname]
-                    if self._original_document else None)
+            time = (self.persisted_document[fieldname]
+                    if self.persisted_document else None)
 
-        if time is None:
-            return None
-
-        return time.replace(tzinfo=None)
+        return time.replace(tzinfo=None) if time is not None else None
 
     def _validate_later_than(self, later_than, field, value):
         """Validate time dependecy.
 
         Value must be at the same time or later than a the value of later_than
+
+        Args:
+            later_than (str): Name of other field for comparison
+            field (string): field name
+            value: field value
+
+        The rule's arguments are validated against this schema:
+        {'type': 'string'}
         """
         other_time = self._get_time(later_than)
         if other_time is None:
@@ -213,6 +236,14 @@ class EventValidator(object):
         """Validate time dependecy.
 
         Value must be at the same time or later than a the value of later_than
+
+        Args:
+            earlier_than (str): Name of other field for comparison
+            field (string): field name
+            value: field value
+
+        The rule's arguments are validated against this schema:
+        {'type': 'string'}
         """
         other_time = self._get_time(earlier_than)
         if other_time is None:
@@ -222,19 +253,20 @@ class EventValidator(object):
             self._error(field, "Must be at a point in time before %s" %
                         earlier_than)
 
-    def _validate_only_if_not_null(self, only_if_not_null,
-                                   field, value):
+    def _validate_only_if_not_null(self, only_if_not_null, field, _):
         """The field may only be set if another field is not None.
 
         Args:
             only_if_not_null (string): The field, that may not be None
             field (string): name of the validated field
-            value: Value of the validated field
+
+        The rule's arguments are validated against this schema:
+        {'type': 'string'}
         """
         doc = self.document
         exists_in_original = (  # Check original document in case of patches
-            self._original_document is not None and
-            self._original_document.get(only_if_not_null) is not None)
+            self.persisted_document is not None and
+            self.persisted_document.get(only_if_not_null) is not None)
 
         if doc.get(only_if_not_null) is None and not exists_in_original:
             self._error(field, "May only be specified if %s is not null"
@@ -243,17 +275,32 @@ class EventValidator(object):
     def _validate_required_if_not(self, *args):
         """Dummy function for Cerberus.(It complains if it can find the rule).
 
-        Functionality is implemented in the requierd field validation.
+        Functionality is implemented in the required field validation.
+
+        The rule's arguments are validated against this schema:
+        {'type': 'string'}
         """
 
-    def _validate_required_fields(self, document):
+    def _BareValidator__validate_required_fields(self, document):
         """Extend the parsing of to support requirements depending on fields.
 
         Needed for language fields, where either german or english is needed.
         The new requirement validator will (in addition to the default
         `required` field) check for a a `required_`
+
+        Note on the weird name:
+        Cerberus defines the validation of required fields with double
+        underscores. Such variables undergo 'name mangling' in python,
+        and `__func` is replaces by `_classname_func` in the class definition,
+        a mechanism to avoid name collisions [1].
+
+        However, we precisely need to overwrite this function, hence
+        the weird name, as it is defined in the Cerberus `BareValidator` class.
+
+
+        1: https://docs.python.org/3/tutorial/classes.html#tut-private
         """
-        super()._validate_required_fields(document)
+        super()._BareValidator__validate_required_fields(document)
 
         for field, schema in self.schema.items():
             # If the field is there do nothing

--- a/amivapi/events/validation.py
+++ b/amivapi/events/validation.py
@@ -23,6 +23,7 @@ class EventValidator(object):
         3.  Validate schema and get all errors with prefix 'additional_fields:'
 
         Args:
+            field (string): field name
             value: field value
 
         The rule's arguments are validated against this schema:
@@ -153,6 +154,7 @@ class EventValidator(object):
         3.  Is it a valid json-schema?
 
         Args:
+            field (string): field name
             value: field value
 
         1: https://json-schema.org

--- a/amivapi/groups/model.py
+++ b/amivapi/groups/model.py
@@ -177,13 +177,13 @@ groupdomain = {
             },
             'permissions': {
                 'type': 'dict',
-                'propertyschema': {'type': 'string',
-                                   'api_resources': True},
+                'keyschema': {'type': 'string',
+                              'api_resources': True},
                 'valueschema': {'type': 'string',
                                 'allowed': ['read', 'readwrite']},
                 'nullable': True,
                 'description': 'permissions the group grants. The value is a '
-                'json object with resources as properties and "read" or '
+                'json object with resources as keys and "read" or '
                 '"readwrite" as a value.'
                 # TODO: Make the schema available as a jsonschema
             }

--- a/amivapi/groups/validation.py
+++ b/amivapi/groups/validation.py
@@ -18,6 +18,9 @@ class GroupValidator(object):
 
         Users can only sign up themselves
         Moderators and admins can sign up everyone
+
+        The rule's arguments are validated against this schema:
+        {'type': 'boolean'}
         """
         if enabled and not g.get('resource_admin'):
             # Get moderator id
@@ -38,6 +41,9 @@ class GroupValidator(object):
 
         Validates if the group allows self enrollment.
         Group moderator and admins can enroll anyway.
+
+        The rule's arguments are validated against this schema:
+        {'type': 'boolean'}
         """
         if enabled and not g.get('resource_admin'):
             # Check if moderator
@@ -50,17 +56,25 @@ class GroupValidator(object):
                             " and you are not the group moderator.")
 
     def _validate_unique_elements(self, enabled, field, value):
-        """Validate that a list does only contain unique elements."""
+        """Validate that a list does only contain unique elements.
+
+        The rule's arguments are validated against this schema:
+        {'type': 'boolean'}
+        """
         if enabled:
             if len(value) > len(set(value)):
                 self._error(field, "All list elements must be unique.")
 
     def _validate_unique_elements_for_resource(self, enabled, field, value):
-        """Validate that no list elements exists in another items list."""
+        """Validate that no list elements exists in another items list.
+
+        The rule's arguments are validated against this schema:
+        {'type': 'boolean'}
+        """
         if enabled:
             # Ignore values already present in original document if updating
-            if self._original_document is not None:
-                old_list = self._original_document.get(field, [])
+            if self.persisted_document is not None:
+                old_list = self.persisted_document.get(field, [])
                 elements = (e for e in value if e not in old_list)
             else:
                 elements = value

--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -33,7 +33,7 @@ AUTO_COLLAPSE_MULTI_KEYS = True
 AUTO_CREATE_LISTS = True
 RESOURCE_METHODS = ['GET', 'POST']
 ITEM_METHODS = ['GET', 'PATCH', 'DELETE']
-XML = False
+RENDERERS = ['eve.render.JSONRenderer']
 X_DOMAINS = '*'
 X_HEADERS = ['Authorization', 'Content-Type', 'Cache-Control',
              'If-Match', 'If-None-Match', 'If-Modified-Since']

--- a/amivapi/tests/events/test_secret.py
+++ b/amivapi/tests/events/test_secret.py
@@ -1,6 +1,6 @@
 """Test creation of secret key."""
 
-from mock import patch
+from unittest.mock import patch
 
 from amivapi.tests.utils import WebTestNoAuth
 from amivapi.events.utils import (

--- a/amivapi/tests/events/test_validators.py
+++ b/amivapi/tests/events/test_validators.py
@@ -18,7 +18,8 @@ class EventValidatorTest(WebTestNoAuth):
         self.app.register_resource('test', {
             'schema': {
                 'field': {
-                    'type': 'json_schema_object'
+                    'type': 'string',
+                    'json_schema': True,
                 }
             }
         })

--- a/amivapi/tests/groups/test_mailing_lists.py
+++ b/amivapi/tests/groups/test_mailing_lists.py
@@ -14,7 +14,7 @@ from os.path import isfile, join
 from shutil import rmtree
 from tempfile import mkdtemp
 
-from mock import patch, call
+from unittest.mock import patch, call
 
 from amivapi.tests.utils import WebTestNoAuth, skip_if_false
 

--- a/amivapi/tests/groups/test_model.py
+++ b/amivapi/tests/groups/test_model.py
@@ -34,7 +34,7 @@ class GroupModelTest(WebTest):
         data = {
             'name': 'testgroup',
             'moderator': 24 * '0',
-            'receive_from': ['test1@amiv.ch', 'test2@amiv.ch'],
+            'receive_from': ['test1', 'test2'],
             'forward_to': ['test3@amiv.ch', 'test4@amiv.ch'],
         }
         self.api.post("/groups", data=data, token=self.get_root_token(),

--- a/amivapi/tests/test_ldap.py
+++ b/amivapi/tests/test_ldap.py
@@ -11,7 +11,7 @@ There is another file, "ldap_integration.py", which can be used to test
 integration with the real ldap. More info there.
 """
 
-from mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch, call
 import warnings
 
 from os import getenv

--- a/amivapi/validation.py
+++ b/amivapi/validation.py
@@ -1,51 +1,118 @@
+"""Custom Validator Class.
+
+Custom validation rules defined here are used in multiple resources.
+Validation rules used for single resources only can be found in the respective
+resource directory.
+
+Note the following phrase at the end of every validaton function docstring:
+`The rule's arguments are validated against this schema:`
+
+Cerberus expects this string followed by a schema in the docstring to
+validate the schema itself.
+[Read more](http://docs.python-cerberus.org/en/stable/customize.html)
+"""
+
+from datetime import datetime, timedelta, timezone
 from imghdr import what
 
-from eve.io.mongo import Validator
+from eve.io.mongo import Validator as Validator
 from flask import current_app as app
 from flask import abort, g, request
-from datetime import datetime, timedelta, timezone
+from cerberus import TypeDefinition, utils
 
 
 class ValidatorAMIV(Validator):
     """Validator subclass adding more validation for special fields."""
 
+    @property
+    def ignore_none_values(self):
+        """Treat None values like missing fields for the `required` and
+        `unique` validators.
+        """
+        return True
+
+
+    types_mapping = Validator.types_mapping.copy()
+    types_mapping['timedelta'] = TypeDefinition('timedelta', (timedelta,), ())
+
+
+    def _validate_data_relation(self, data_relation, field, value):
+        """Extend the arguments for data_relation to include cascading delete.
+
+        The rule's arguments are validated against this schema:
+        {'type': 'dict',
+            'schema': {
+                'resource': {'type': 'string', 'required': True},
+                'field': {'type': 'string', 'required': True},
+                'embeddable': {'type': 'boolean', 'default': False},
+                'version': {'type': 'boolean', 'default': False},
+                'cascade_delete': {'type': 'boolean', 'default': False}
+            }
+        }
+        """
+        super()._validate_data_relation(data_relation, field, value)
+
+
     def _validate_api_resources(self, enabled, field, value):
-        """Value must be in api domain."""
+        """Value must be in api domain.
+
+        Args:
+            enabled (bool): Boolean, should be true to use the rule
+            field (string): field name
+            value (string): field value
+
+        The rule's arguments are validated against this schema:
+        {'type': 'boolean'}
+        """
         if enabled and value not in app.config['DOMAIN']:
             self._error(field, "'%s' is not a api resource." % value)
 
-    def _validate_not_patchable(self, enabled, field, value):
-        """Custom Validator to inhibit patching of the field.
-
-        e.g. eventsignups, userid: required for post, but can not be patched
-
-        Args:
-            enabled (bool): Boolean, should be true
-            field (string): field name.
-            value: field value.
-        """
-        if enabled and (request.method == 'PATCH'):
-            self._error(field, "this field can not be changed with PATCH")
-
-    def _validate_not_patchable_unless_admin(self, enabled, field, value):
+    def _validate_not_patchable(self, enabled, field, _):
         """Inhibit patching of the field.
 
         e.g. eventsignups, userid: required for post, but can not be patched
 
         Args:
-            enabled (bool): Boolean, should be true
-            field (string): field name.
-            value: field value.
+            enabled (bool): Boolean, should be true to use the rule
+            field (string): field name
+
+        The rule's arguments are validated against this schema:
+        {'type': 'boolean'}
+        """
+        if enabled and (request.method == 'PATCH'):
+            self._error(field, "this field can not be changed with PATCH")
+
+    def _validate_not_patchable_unless_admin(self, enabled, field, _):
+        """Inhibit patching of the field for non-admins.
+
+        e.g. eventsignups, userid: required for post, but can not be patched
+
+        Args:
+            enabled (bool): Boolean, should be true to use the rule
+            field (string): field name
+
+        The rule's arguments are validated against this schema:
+        {'type': 'boolean'}
         """
         if enabled and (request.method == 'PATCH') and not g.resource_admin:
             self._error(field, "this field can not be changed with PATCH "
                         "unless you have admin rights.")
 
-    def _validate_admin_only(self, enabled, field, value):
-        """Prohibit anyone except admins from setting this field."""
+    def _validate_admin_only(self, enabled, field, _):
+        """Prohibit anyone except admins from setting this field.
+
+        Applies to POST and PATCH.
+
+        Args:
+            enabled (bool): Boolean, should be true to use the rule
+            field (string): field name
+
+        The rule's arguments are validated against this schema:
+        {'type': 'boolean'}
+        """
         if enabled and not g.resource_admin:
-            self._error(field, "This field can only be set with admin "
-                        "permissions.")
+            self._error(field,
+                        "This field can only be set with admin permissions.")
 
     def _validate_unique_combination(self, unique_combination, field, value):
         """Validate that a combination of fields is unique.
@@ -59,9 +126,12 @@ class ValidatorAMIV(Validator):
         required etc)
 
         Args:
-            unique_combination (list): combination fields
-            field (string): field name.
-            value: field value.
+            unique_combination (list of strings): combination fields
+            field (string): field name
+            value: field value
+
+        The rule's arguments are validated against this schema:
+        {'type': 'list', 'schema': {'type': 'string'}}
         """
         lookup = {field: value}  # self
         for other_field in unique_combination:
@@ -71,7 +141,7 @@ class ValidatorAMIV(Validator):
         # have to be checked but are not part of the document because they will
         # not be patched. We have to load them from the database
         if request.method == 'PATCH':
-            original = self._original_document
+            original = self.persisted_document
             for key in unique_combination:
                 if key not in self.document.keys():
                     lookup[key] = original[key]
@@ -82,14 +152,16 @@ class ValidatorAMIV(Validator):
                         "combination with values for: %s" %
                         unique_combination)
 
-    def _validate_depends_any(self, any_of_fields, field, value):
+    def _validate_depends_any(self, any_of_fields, field, _):
         """Validate, that any of the dependent fields is available
 
         Args:
             any_of_fields (list of strings): A list of fields. One of those
                                              fields must be provided.
-            field (string): This fields name
-            value: This fields value
+            field (string): field name
+
+        The rule's arguments are validated against this schema:
+        {'type': 'list', 'schema': {'type': 'string'}}
         """
         if request.method == 'POST':
             for possible_field in any_of_fields:
@@ -98,7 +170,7 @@ class ValidatorAMIV(Validator):
             self._error(field, "May only be provided, if any of %s is set"
                         % ", ".join(any_of_fields))
 
-    def _validate_filetype(self, filetype, field, value):
+    def _validate_filetype(self, allowed_types, field, value):
         """Validate filetype. Can validate images and pdfs.
 
         pdf: Check if first 4 characters are '%PDF' because that marks
@@ -111,19 +183,22 @@ class ValidatorAMIV(Validator):
         recognized!
 
         Args:
-            filetype (list): filetypes, e.g. ['pdf', 'png']
-            field (string): field name.
-            value: field value.
+            allowed_types (list of strings): filetypes, e.g. ['pdf', 'png']
+            field (string): field name
+            value: field value
+
+        The rule's arguments are validated against this schema:
+        {'type': 'list', 'schema': {'type': 'string'}}
         """
         is_pdf = value.read(4) == br'%PDF'
         value.seek(0)  # Go back to beginning for what()
-        t = 'pdf' if is_pdf else what(value)
+        filetype = 'pdf' if is_pdf else what(value)
 
-        if not(t in filetype):
+        if filetype not in allowed_types:
             self._error(field, "filetype '%s' not supported, has to be in: "
-                        "%s" % (t, filetype))
+                        "%s" % (filetype, allowed_types))
 
-    def _validate_session_younger_than(self, threshold_timedelta, field, value):
+    def _validate_session_younger_than(self, threshold_timedelta, field, _):
         """Validation of the used token for special fields
 
         Validates if the session is not older than threshold_time
@@ -132,8 +207,10 @@ class ValidatorAMIV(Validator):
 
         Args:
             threshold_timedelta (timedelta): threshold to compare with
-            field (string): field name.
-            value: field value.
+            field (string): field name
+
+        The rule's arguments are validated against this schema:
+        {'type': 'timedelta'}
         """
         if threshold_timedelta < timedelta(seconds=0):
             # Use abort to actually give a stacktrace and break tests.
@@ -149,3 +226,15 @@ class ValidatorAMIV(Validator):
                 self._error(field, "Your session is too old. Using this field "
                             "is not allowed if your session is older than %s."
                             % threshold_timedelta)
+
+
+# Cerberus uses a different validator for schemas, which is unaware of
+# custom types.
+# This validation class is created on the fly and cannot be chosen [1]
+# The function to create a new validator [2] uses a fixed base validator
+# (which is put into globals for some reason) [3], which we can replace with
+# our type-aware AmivValidator
+# 1: https://github.com/pyeve/cerberus/blob/1.1/cerberus/schema.py#L23-L24
+# 2: https://github.com/pyeve/cerberus/blob/1.1/cerberus/utils.py#L69-L95
+# 3: https://github.com/pyeve/cerberus/blob/1.1/cerberus/utils.py#L24-L28
+utils.get_Validator_class = lambda: ValidatorAMIV

--- a/amivapi/validation.py
+++ b/amivapi/validation.py
@@ -31,10 +31,8 @@ class ValidatorAMIV(Validator):
         """
         return True
 
-
     types_mapping = Validator.types_mapping.copy()
     types_mapping['timedelta'] = TypeDefinition('timedelta', (timedelta,), ())
-
 
     def _validate_data_relation(self, data_relation, field, value):
         """Extend the arguments for data_relation to include cascading delete.
@@ -51,7 +49,6 @@ class ValidatorAMIV(Validator):
         }
         """
         super()._validate_data_relation(data_relation, field, value)
-
 
     def _validate_api_resources(self, enabled, field, value):
         """Value must be in api domain.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,10 @@
-eve==0.7.4
+eve==0.8
 -e git+https://github.com/hermannsblum/eve-swagger.git@5c9cf066ffa72712f9018a3eb0c5142f7733d8cc#egg=Eve_Swagger
 -e git+https://github.com/NotSpecial/nethz.git@1d3004081c3618f1f41463476a847b0bddd6d91a#egg=nethz
-Flask==0.10.1
 passlib==1.6.5
 jsonschema==2.5.1
 click==6.6
 pytz==2016.7
 freezegun==0.3.8
-# Mock is only available in the standard lib from 3.3 on
-mock==2.0.0
 # Install amivapi in editable mode to enable command line tools
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
 eve==0.8
 -e git+https://github.com/hermannsblum/eve-swagger.git@5c9cf066ffa72712f9018a3eb0c5142f7733d8cc#egg=Eve_Swagger
 -e git+https://github.com/NotSpecial/nethz.git@1d3004081c3618f1f41463476a847b0bddd6d91a#egg=nethz
-Flask==0.10.1
-# Because of issues with Flask-PyMongo 2.0.0. See https://github.com/pyeve/eve/issues/1172.
-Flask-PyMongo==0.5.2
 passlib==1.6.5
 jsonschema==2.5.1
 click==6.6


### PR DESCRIPTION
Eve 0.8 brings Cerberus 1.0, which requires lots of changes:

- Several properties have been renamed
- type checking is now handled differently
- validation rules require a schema in the docstring to validate the schema
  itself

This patch updates AMIV API to work with Cerberus 1.0.