### PR TITLE
Fix test config and eventsignup validation

### DIFF
--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -235,14 +235,9 @@ eventdomain = {
                 'type': 'objectid',
                 'nullable': False,
                 'unique_combination': ['event'],
+                'required': True,
+                'excludes': 'email',
                 'description': 'Provide either user or email.',
-
-                # This creates a presence XOR with email
-                # Cerberus <= 1.2: Causes problems with `None` values, which
-                # should be treated as missing fields, which is not yet
-                # possible, causing problems if `None` already exists in db
-                # 'required': True,
-                # 'excludes': ['email']
             },
             'additional_fields': {
                 'nullable': True,
@@ -259,14 +254,11 @@ eventdomain = {
                 'regex': EMAIL_REGEX,
                 'type': 'string',
                 'unique_combination': ['event'],
+                'required': True,
+                'excludes': 'user',
                 'description': 'For registered users, this is just a projection'
                 ' of your general email-address. External users need to provide'
                 ' their email here.',
-
-                # This creates a presence XOR with user
-                # see above
-                # 'required': True,
-                # 'excludes': ['user']
             },
             'confirmed': {
                 'type': 'boolean',

--- a/amivapi/tests/events/test_model.py
+++ b/amivapi/tests/events/test_model.py
@@ -33,6 +33,28 @@ class EventModelTest(WebTestNoAuth):
             'user': str(user['_id'])
         }, status_code=422)
 
+    def test_email_or_user(self):
+        """A signup requires email XOR user."""
+        event = str(self.new_object("events",
+                                    spots=0,
+                                    allow_email_signup=True)['_id'])
+        user = str(self.new_object("users")['_id'])
+        email = 'test@test.test'
+
+        # Bad: Nothing or both email and user
+        self.api.post("/eventsignups", data={'event': event},
+                      status_code=422)
+        self.api.post("/eventsignups", data={'event': event,
+                                             'user': user,
+                                             'email': email},
+                      status_code=422)
+
+        # Good: One of both
+        self.api.post("/eventsignups", data={'event': event, 'user': user},
+                      status_code=201)
+        self.api.post("/eventsignups", data={'event': event, 'email': email},
+                      status_code=201)
+
     def test_additional_fields_must_satisfy_constraints(self):
         """Test that the jsonschema constraints must always be met."""
 

--- a/amivapi/tests/test_sentry.py
+++ b/amivapi/tests/test_sentry.py
@@ -11,6 +11,7 @@ from flask.signals import got_request_exception
 
 from amivapi.tests.utils import WebTestNoAuth, skip_if_false
 
+
 # Get test dsn from environment
 SENTRY_DSN = getenv('SENTRY_TEST_DSN')
 

--- a/amivapi/tests/utils.py
+++ b/amivapi/tests/utils.py
@@ -101,6 +101,8 @@ class WebTest(unittest.TestCase, FixtureMixin):
         'DEBUG': True,   # This makes eve's error messages more helpful
         'LDAP_USERNAME': None,  # LDAP test require special treatment
         'LDAP_PASSWORD': None,  # LDAP test require special treatment
+        'SENTRY_DSN': None,
+        'SENTRY_ENVIRONMENT': None,
         'PASSWORD_CONTEXT': CryptContext(
             schemes=["pbkdf2_sha256"],
 


### PR DESCRIPTION
First of all, the test config would load sentry config from a file in the
current working dir. Not anymore :)

Furthermore, eventsignups with email would crash the API.

To fix this, a proper combination of `required` and `exclude` was needed,
which is able to to ignore None values. (None equals not set)

As Cerberus is a bit inconsequential about None values
(e.g. they can be ignored for `required`, but not for `exclude`), this
required patching how Cerberus handles exludes.

Resolves #213