### PR TITLE
Remove admin privileges for session_younger_than validator

### DIFF
--- a/amivapi/tests/test_validation.py
+++ b/amivapi/tests/test_validation.py
@@ -56,7 +56,7 @@ class ValidatorAMIVTest(WebTest):
         self.new_object("groupmemberships",
                         user=user['_id'], group=admin_group['_id'])
 
-        # User is now admin, so can always post
+        # User is now admin, should have same restrictions
         self.api.post("/test", data={
             'field1': 'teststring2'
-        }, token=old_token, status_code=201)
+        }, token=old_token, status_code=422)

--- a/amivapi/users/__init__.py
+++ b/amivapi/users/__init__.py
@@ -4,7 +4,7 @@
 #          you to buy us beer if we meet and you like the software.
 """User module initialization."""
 
-from amivapi.utils import register_domain
+from amivapi.utils import register_domain, register_validator
 
 from .model import userdomain
 from .security import (
@@ -16,11 +16,13 @@ from .security import (
     project_password_status_on_updated,
     restrict_filters,
 )
+from .validation import UserValidator
 
 
 def init_app(app):
     """Register resources and blueprints, add hooks and validation."""
     register_domain(app, userdomain)
+    register_validator(app, UserValidator)
 
     # Dynamically restrict filter
     app.on_pre_GET_users += restrict_filters

--- a/amivapi/users/validation.py
+++ b/amivapi/users/validation.py
@@ -1,0 +1,48 @@
+"""Custom Validator Class.
+
+Custom validation rules defined here are used in multiple resources.
+Validation rules used for single resources only can be found in the respective
+resource directory.
+
+Note the following phrase at the end of every validaton function docstring:
+`The rule's arguments are validated against this schema:`
+
+Cerberus expects this string followed by a schema in the docstring to
+validate the schema itself.
+[Read more](http://docs.python-cerberus.org/en/stable/customize.html)
+"""
+
+from datetime import datetime
+from flask import g, request
+
+
+class UserValidator(object):
+    """Validator subclass adding more validation for usuers."""
+
+    def _validate_session_younger_than(self, threshold_timedelta, field, _):
+        """Validate that the session is fresh enough to change this field.
+
+        E.g. the password may only be changed with a recent session.
+
+        Only applies to updates.
+
+        Args:
+            threshold_timedelta (timedelta): threshold to compare with
+            field (string): field name
+
+        The rule's arguments are validated against this schema:
+        {'type': 'timedelta', 'min': 0}
+        """
+        # When not updating or if there is no session, this validator has
+        # nothing to do
+        if request.method != 'PATCH' or not g.current_session:
+            return
+
+        # timezone is always utc, so we can remove tzinfo safely
+        time_created = g.current_session['_created'].replace(tzinfo=None)
+        time_now = datetime.utcnow()
+
+        if time_now - time_created > threshold_timedelta:
+            self._error(field, "Your session is too old. Using this field "
+                        "is not allowed if your session is older than %s."
+                        % threshold_timedelta)

--- a/amivapi/validation.py
+++ b/amivapi/validation.py
@@ -12,13 +12,12 @@ validate the schema itself.
 [Read more](http://docs.python-cerberus.org/en/stable/customize.html)
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from imghdr import what
 from collections import Hashable
 
 from eve.io.mongo import Validator as Validator
-from flask import current_app as app
-from flask import abort, g, request
+from flask import current_app as app, g, request
 from cerberus import TypeDefinition, utils
 
 
@@ -218,32 +217,6 @@ class ValidatorAMIV(Validator):
         if filetype not in allowed_types:
             self._error(field, "filetype '%s' not supported, has to be in: "
                         "%s" % (filetype, allowed_types))
-
-    def _validate_session_younger_than(self, threshold_timedelta, field, _):
-        """Validation of the used token for special fields
-
-        Validates if the session is not older than threshold_time
-
-        Args:
-            threshold_timedelta (timedelta): threshold to compare with
-            field (string): field name
-
-        The rule's arguments are validated against this schema:
-        {'type': 'timedelta'}
-        """
-        if threshold_timedelta < timedelta(seconds=0):
-            # Use abort to actually give a stacktrace and break tests.
-            abort(500, "Invalid field definition: %s: %s, "
-                  "session_younger_than must be positive."
-                  % (self.resource, field))
-
-        time_created = g.current_session['_created']
-        time_now = datetime.now(timezone.utc)
-
-        if time_now - time_created > threshold_timedelta:
-            self._error(field, "Your session is too old. Using this field "
-                        "is not allowed if your session is older than %s."
-                        % threshold_timedelta)
 
 
 # Cerberus uses a different validator for schemas, which is unaware of

--- a/amivapi/validation.py
+++ b/amivapi/validation.py
@@ -224,8 +224,6 @@ class ValidatorAMIV(Validator):
 
         Validates if the session is not older than threshold_time
 
-        Except admins, they can ignore this
-
         Args:
             threshold_timedelta (timedelta): threshold to compare with
             field (string): field name
@@ -239,14 +237,13 @@ class ValidatorAMIV(Validator):
                   "session_younger_than must be positive."
                   % (self.resource, field))
 
-        if not g.get('resource_admin'):
-            time_created = g.current_session['_created']
-            time_now = datetime.now(timezone.utc)
+        time_created = g.current_session['_created']
+        time_now = datetime.now(timezone.utc)
 
-            if time_now - time_created > threshold_timedelta:
-                self._error(field, "Your session is too old. Using this field "
-                            "is not allowed if your session is older than %s."
-                            % threshold_timedelta)
+        if time_now - time_created > threshold_timedelta:
+            self._error(field, "Your session is too old. Using this field "
+                        "is not allowed if your session is older than %s."
+                        % threshold_timedelta)
 
 
 # Cerberus uses a different validator for schemas, which is unaware of


### PR DESCRIPTION
Admins should not have special privileges with the `session_younger_than` validator. So administrators should also comply with this validator.

Otherwise, if someone steals the token from an administrator, a password for any user can be set.