### PR TITLE
Replace ModuleNotFoundError with ImportError for compatibility

### DIFF
--- a/amivapi/cli.py
+++ b/amivapi/cli.py
@@ -18,7 +18,7 @@ from amivapi.groups.mailing_lists import updated_group
 
 try:
     import bjoern
-except ModuleNotFoundError:
+except ImportError:
     bjoern = False
 
 


### PR DESCRIPTION
`ModuleNotFoundError` was only introduced in python 3.6.