### PR TITLE
Only send mail when mail server is configured

### DIFF
--- a/amivapi/utils.py
+++ b/amivapi/utils.py
@@ -90,7 +90,7 @@ def mail(sender, to, subject, text):
             'receivers': to,
             'text': text
         })
-    else:
+    elif config.SMTP_SERVER and config.SMTP_PORT:
         msg = MIMEText(text)
         msg['Subject'] = subject
         msg['From'] = sender


### PR DESCRIPTION
This prevents the API from crashing when no mail server is configured.