### PR TITLE
Make link methods compatible with custom resource titles

### DIFF
--- a/amivapi/auth/link_methods.py
+++ b/amivapi/auth/link_methods.py
@@ -162,7 +162,7 @@ def add_permitted_methods_for_home(resource, request, response, payload):
         else:
             # Add links for home
             for res_link in links:
-                res_name = res_link['title']  # title equals resource
+                res_name = res_link['href']  # href equals resource
                 if isinstance(resource_auth(res_name), AmivTokenAuth):
                     check_if_admin(res_name)
                     res_link['methods'] = _get_resource_methods(res_name)

--- a/amivapi/tests/auth/test_link_methods.py
+++ b/amivapi/tests/auth/test_link_methods.py
@@ -297,10 +297,10 @@ class LinkTest(FakeAuthTest):
 
         # Prepare fake response
         response_data = {'_links': {'child': [
-            {'title': "fake"},
-            {'title': "fake_2"},
-            {'title': "fake_no_amiv"},
-            {'title': "fake_nothing"},
+            {'href': "fake"},
+            {'href': "fake_2"},
+            {'href': "fake_no_amiv"},
+            {'href': "fake_nothing"},
         ]}}
 
         response = Response(json.dumps(response_data))
@@ -354,7 +354,7 @@ class LinkIntegrationTest(WebTest):
     def get_user_methods(self, response):
         """Helper to filter GET to home to get methods for user res."""
         for links in response.json['_links']['child']:
-            if links['title'] == 'users':
+            if links['href'] == 'users':
                 return links['methods']
 
     def test_home_public(self):

--- a/amivapi/tests/fixtures.py
+++ b/amivapi/tests/fixtures.py
@@ -191,15 +191,6 @@ class FixtureMixin(object):
                     "unspecified password for session %s"
                     % (obj['username'], obj))
 
-    def preprocess_apikeys(self, schema, obj, fixture):
-        if 'permissions' not in obj:
-            # Create some random permission
-            resource = random.choice(list(self.app.config['DOMAIN'].keys()))
-            permission = (
-                random.choice(schema['permissions']['valueschema']['allowed']))
-
-            obj['permissions'] = {resource: permission}
-
     def preprocess_events(self, schema, obj, fixture):
         """Event validators are pretty complex, so do all thing with custom
         validators by hand"""

--- a/amivapi/tests/fixtures.py
+++ b/amivapi/tests/fixtures.py
@@ -191,6 +191,15 @@ class FixtureMixin(object):
                     "unspecified password for session %s"
                     % (obj['username'], obj))
 
+    def preprocess_apikeys(self, schema, obj, fixture):
+        if 'permissions' not in obj:
+            # Create some random permission
+            resource = random.choice(list(self.app.config['DOMAIN'].keys()))
+            permission = (
+                random.choice(schema['permissions']['valueschema']['allowed']))
+
+            obj['permissions'] = {resource: permission}
+
     def preprocess_events(self, schema, obj, fixture):
         """Event validators are pretty complex, so do all thing with custom
         validators by hand"""


### PR DESCRIPTION
Previously, link methods would check the `title` field to identify a link
resource, which does not work if an alternative title is used.

This issue can be resolved by using the `href` field, as the key in the `DOMAIN` dict equals the endpoint URL.