### PR TITLE
Move schema description validation rules into general validator

### DIFF
--- a/amivapi/groups/model.py
+++ b/amivapi/groups/model.py
@@ -115,7 +115,7 @@ groupdomain = {
 
         # Additional lookup: Since group name is unique, you can use it as url
         'additional_lookup': {
-            'url': 'regex("[\w]+")',
+            'url': r'regex("[\w]+")',
             'field': 'name'
         },
 
@@ -148,7 +148,7 @@ groupdomain = {
                 'schema': {
                     'type': 'string',
                     'maxlength': 100,
-                    'regex': '[a-z0-9_\.-]+'
+                    'regex': r'[a-z0-9_\.-]+'
                 },
                 'description': 'Email addresses of this group. These addresses '
                 'will forward to all group members and the additional addresses'

--- a/amivapi/utils.py
+++ b/amivapi/utils.py
@@ -115,7 +115,7 @@ def mail(sender, to, subject, text):
 
                 try:
                     smtp.sendmail(msg['From'], to, msg.as_string())
-                except smtplib.SMTPRecipientsRefused as e:
+                except smtplib.SMTPRecipientsRefused:
                     error = ("Failed to send mail:\n"
                              "From: %s\nTo: %s\n"
                              "Subject: %s\n\n%s")


### PR DESCRIPTION
We use additional schema rules such as 'description' to make our
schema more descriptive. However, Cerberus will complain about
unknown schema rules, so they have to be defined somewhere,
even if they don't do anything.

Currently, this is done in the documentation sub-module.
This is  a bit problematic, as our API is designed with replaceable
modules in mind -- but deactivating or replacing the doc module would
now cause errors in *all* schemas.

As the additional description rules are important whether or not we
use the online docs, I have moved the rules into the general validator.