### PR TITLE
Fix dockerfile API install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN apk add --no-cache --virtual .deps \
 COPY ./ /api
 RUN pip install -r /api/requirements.txt
 
-# Install amivapi to enable CLI commands
-RUN pip install /api
+# Install amivapi locally to enable CLI commands
+RUN pip install -e /api
 
 # Cleanup dependencies
 RUN apk del .deps


### PR DESCRIPTION
We want the `amivapi` command in the Dockerfile to actually use the files in the `/api` folder.

Therefore, a `-e` flag is needed when pip installs the API in order to avoid copying files to `/usr/lib`.