### PR TITLE
Fix domain initialization

### DIFF
--- a/amivapi/bootstrap.py
+++ b/amivapi/bootstrap.py
@@ -82,6 +82,9 @@ def create_app(config_file=None, **kwargs):
 
     config.update(kwargs)
 
+    # Initialize empty domain to create Eve object, register resources later
+    config['DOMAIN'] = {}
+
     app = Eve("amivapi",  # Flask needs this name to find the static folder
               settings=config,
               validator=ValidatorAMIV)

--- a/amivapi/cli.py
+++ b/amivapi/cli.py
@@ -144,7 +144,7 @@ def run(config, mode):
 
     - prod: Run a production server (requires the `bjoern` module)
     """
-      if mode == 'dev':
+    if mode == 'dev':
         app = create_app(config_file=config,
                          ENV='development',
                          DEBUG=True,

--- a/amivapi/cli.py
+++ b/amivapi/cli.py
@@ -144,15 +144,17 @@ def run(config, mode):
 
     - prod: Run a production server (requires the `bjoern` module)
     """
-    app = create_app(config_file=config, DEBUG=True, TESTING=True)
-
-    if mode == 'dev':
+      if mode == 'dev':
+        app = create_app(config_file=config,
+                         ENV='development',
+                         DEBUG=True,
+                         TESTING=True)
         app.run(threaded=True)
 
     elif mode == 'prod':
         if bjoern:
             echo('Starting bjoern on port 8080...')
-            bjoern.run(create_app(), '0.0.0.0', 8080)
+            bjoern.run(create_app(config_file=config), '0.0.0.0', 8080)
         else:
             raise ClickException('The production server requires `bjoern`, '
                                  'try installing it with '

--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -13,7 +13,7 @@ from datetime import timedelta
 
 from passlib.context import CryptContext
 
-VERSION = '2.0.1'
+VERSION = '2.0.2'
 
 # Sentry
 
@@ -28,7 +28,6 @@ TESTING = False
 # Eve & Amivapi
 
 # AUTH_FIELD = "_author"  # TODO(Alex): If we enable oplog, do we need this?
-DOMAIN = {}  # Empty add first, resource will be added in bootstrap
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 EMAIL_REGEX = '^.+@.+$'
 BANDWIDTH_SAVER = False

--- a/amivapi/tests/test_media.py
+++ b/amivapi/tests/test_media.py
@@ -42,7 +42,6 @@ class MediaTest(WebTestNoAuth):
                 }
             }
         })
-        print('I WAS HEREEE', 'test' in self.app.config['DOMAIN'])
 
     def _post_file(self):
         """Post file. Use BytesIO to be able to set the filename."""

--- a/amivapi/tests/test_media.py
+++ b/amivapi/tests/test_media.py
@@ -32,8 +32,17 @@ class MediaTest(WebTestNoAuth):
 
     def setUp(self):
         """Add test resource."""
-        self.test_config['DOMAIN'] = {'test': test_resource}
         super().setUp()
+        self.app.register_resource('test', {
+            'resource_methods': ['POST', 'GET'],
+            'item_methods': ['GET', 'DELETE'],
+            'schema': {
+                'test_file': {
+                    'type': 'media'
+                }
+            }
+        })
+        print('I WAS HEREEE', 'test' in self.app.config['DOMAIN'])
 
     def _post_file(self):
         """Post file. Use BytesIO to be able to set the filename."""

--- a/amivapi/tests/utils.py
+++ b/amivapi/tests/utils.py
@@ -146,8 +146,6 @@ class WebTest(unittest.TestCase, FixtureMixin):
 
     def tearDown(self):
         """Tear down after testing."""
-        # Reset domain (otherwise saved between tests which causes errors)
-        self.app.config['DOMAIN'].clear()
         # delete testing database
         self.connection.drop_database(self.test_config['MONGO_DBNAME'])
         # close database connection


### PR DESCRIPTION
Eve does not allow schemas to contain fields such as `_id` or `_etag`.

However, we want to create them for better documentation.

This is no problem if we add them after Eve's check (which cannot be disabled :/),
but in the current implementation, this would all mutate the domain dict defined in settings.

Thus, if a second app were to be created in the same python interpreter, the domain would already be filled and Eve would complain.

Until now, this was only an issue with the tests, so I reset the domain after each test run.
However, due to a small mistake, the CLI would call `create_app` twice.

Normally, this should not be an issue. However, the situation explained above would cause Eve to complain and crash.

Now I decided to fix the problem more properly:

Instead of a fixed dict in `settings.py`, a fresh dict is now initialized in `create_app`.