### PR TITLE
Inhibit public signups with user mail addresses

### DIFF
--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -525,6 +525,7 @@ eventdomain = {
                 "example": None,
 
                 'email_signup_must_be_allowed': True,
+                'no_user_mail': True,
                 'maxlength': 100,
                 'not_patchable': True,
                 'nullable': False,

--- a/amivapi/events/validation.py
+++ b/amivapi/events/validation.py
@@ -269,6 +269,18 @@ class EventValidator(object):
             self._error(field, "May only be specified if %s is not null"
                         % only_if_not_null)
 
+    def _validate_no_user_mail(self, enabled, field, value):
+        """Validate that the mail address does not belong to a user.
+
+        The rule's arguments are validated against this schema:
+        {'type': 'boolean'}
+        """
+        users = current_app.data.driver.db['users']
+        if enabled and users.find({'email': value}).count() > 0:
+            self._error(field, "The email address '%s' "
+                               "is already registered with a user and cannot "
+                               "be used for public signup." % value)
+
     def _validate_required_if_not(self, *args):
         """Dummy function for Cerberus.(It complains if it can find the rule).
 

--- a/amivapi/tests/events/test_model.py
+++ b/amivapi/tests/events/test_model.py
@@ -164,6 +164,15 @@ class EventModelTest(WebTestNoAuth):
             'event': str(ev['_id'])
         }, status_code=201)
 
+    def test_email_signup_unknown_mail(self):
+        """External signups cannot use email addresses form existing users."""
+        ev = self.new_object("events", spots=100, allow_email_signup=True)
+        self.new_object("users", email='already@taken.ch')
+        self.api.post("/eventsignups", data={
+            'email': 'already@taken.ch',
+            'event': str(ev['_id'])
+        }, status_code=422)
+
     def test_spots_none(self):
         """Test you can set spots to None and this does not require deps."""
         self.api.post('/events', data=self.event_data({


### PR DESCRIPTION
Currently the email of a user can be used for an anonymous signup, which does not make sense.

Users should only signup as users, not anonymously with their email addresses.

Resolves #330