### PR TITLE
Increment version for new eventsignups validation

### DIFF
--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -13,7 +13,7 @@ from datetime import timedelta
 
 from passlib.context import CryptContext
 
-VERSION = '2.0.4'
+VERSION = '2.1.0'
 
 # Sentry
 


### PR DESCRIPTION
I forgot to increment the version when implementing #333.

As it is quite important for useful sentry reports etc. to have an accurate version number,
I want to do this now :)