### PR TITLE
Fix typo in events documentation

### DIFF
--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -297,7 +297,7 @@ eventdomain = {
                 'title': 'Thumbnail',
                 'description': 'Event advertisement image thumbnail, e.g. '
                                'for preview and newsletter. Must have an '
-                               'aspect ratio of 1:9. (`.jpeg` or `.png`)',
+                               'aspect ratio of 1:1. (`.jpeg` or `.png`)',
                 'filetype': ['png', 'jpeg'],
                 'type': 'media',
                 'aspect_ratio': (1, 1),

--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -13,7 +13,7 @@ from datetime import timedelta
 
 from passlib.context import CryptContext
 
-VERSION = '2.1.0'
+VERSION = '2.1.1'
 
 # Sentry
 


### PR DESCRIPTION
The aspect ratio for the event thumbnail image is wrong in the documentation. The thumbnail must have an aspect ratio of 1:1.