### PR TITLE
Metadata summary for study documents

### DIFF
--- a/amivapi/studydocs/__init__.py
+++ b/amivapi/studydocs/__init__.py
@@ -12,10 +12,7 @@ from amivapi.studydocs.authorization import (
     add_uploader_on_bulk_insert,
     add_uploader_on_insert
 )
-from amivapi.studydocs.summary import (
-    save_lookup,
-    add_summary,
-)
+from amivapi.studydocs.summary import add_summary
 from amivapi.studydocs.model import studydocdomain, StudyDocValidator
 from amivapi.utils import register_domain, register_validator
 
@@ -28,5 +25,4 @@ def init_app(app):
     app.on_insert_item_studydocuments += add_uploader_on_insert
     app.on_insert_studydocuments += add_uploader_on_bulk_insert
 
-    app.on_pre_GET_studydocuments += save_lookup
     app.on_fetched_resource_studydocuments += add_summary

--- a/amivapi/studydocs/__init__.py
+++ b/amivapi/studydocs/__init__.py
@@ -12,13 +12,21 @@ from amivapi.studydocs.authorization import (
     add_uploader_on_bulk_insert,
     add_uploader_on_insert
 )
-from amivapi.studydocs.model import studydocdomain
-from amivapi.utils import register_domain
+from amivapi.studydocs.summary import (
+    save_lookup,
+    add_summary,
+)
+from amivapi.studydocs.model import studydocdomain, StudyDocValidator
+from amivapi.utils import register_domain, register_validator
 
 
 def init_app(app):
     """Register resources and blueprints, add hooks and validation."""
     register_domain(app, studydocdomain)
+    register_validator(app, StudyDocValidator)
 
     app.on_insert_item_studydocuments += add_uploader_on_insert
     app.on_insert_studydocuments += add_uploader_on_bulk_insert
+
+    app.on_pre_GET_studydocuments += save_lookup
+    app.on_fetched_resource_studydocuments += add_summary

--- a/amivapi/studydocs/model.py
+++ b/amivapi/studydocs/model.py
@@ -38,7 +38,36 @@ file uploaders have additional permissions:
 
 ## Summary
 
-TODO(Alex)
+For more efficient searching of study documents, a *summary* of available
+metadata fields can be requested with the `summary` keyword in the query string:
+
+```
+/studydocuments?summary
+/studydocuments?where={some filter}&summary
+```
+
+When a summary is requested, the response will contain a new field
+`_summary`, which contains additional information on metadata fields
+listing all distinct values for each field along with the number of documents
+available.
+
+```
+_summary:
+    professor:
+        Prof. Dr. Awesome: 10
+        Prof. Okay: 5
+        ...
+    lecture:
+        ...
+    ...
+```
+
+The summary is only computed for documents matching the current `where` query,
+e.g. when searching for ITET documents, only professors related to ITET
+documents will show up in the summary.
+
+Furthermore, the `author` metadata field is excluded from the summary, as there
+are only very few documents for most authors, thus not much to summarize.
 """)
 
 
@@ -114,14 +143,15 @@ studydocdomain = {
                 'empty': False,
                 'nullable': True,
                 'default': None,
-                'no_html': True
+                'no_html': True,
             },
             'department': {
                 'example': DEPARTMENT_LIST[0],
                 'type': 'string',
                 'nullable': True,
                 'default': None,
-                'allowed': DEPARTMENT_LIST
+                'allowed': DEPARTMENT_LIST,
+                'allow_summary': True,
             },
 
             'lecture': {

--- a/amivapi/studydocs/model.py
+++ b/amivapi/studydocs/model.py
@@ -65,9 +65,6 @@ _summary:
 The summary is only computed for documents matching the current `where` query,
 e.g. when searching for ITET documents, only professors related to ITET
 documents will show up in the summary.
-
-Furthermore, the `author` metadata field is excluded from the summary, as there
-are only very few documents for most authors, thus not much to summarize.
 """)
 
 
@@ -144,6 +141,7 @@ studydocdomain = {
                 'nullable': True,
                 'default': None,
                 'no_html': True,
+                'allow_summary': True,
             },
             'department': {
                 'example': DEPARTMENT_LIST[0],

--- a/amivapi/studydocs/model.py
+++ b/amivapi/studydocs/model.py
@@ -39,17 +39,10 @@ file uploaders have additional permissions:
 ## Summary
 
 For more efficient searching of study documents, a *summary* of available
-metadata fields can be requested with the `summary` keyword in the query string:
-
-```
-/studydocuments?summary
-/studydocuments?where={some filter}&summary
-```
-
-When a summary is requested, the response will contain a new field
-`_summary`, which contains additional information on metadata fields
-listing all distinct values for each field along with the number of documents
-available.
+metadata fields is returned in a `_summary` field of the response,
+which contains additional information on metadata fields.
+It lists all distinct values for each field along with the number of
+documents available.
 
 ```
 _summary:

--- a/amivapi/studydocs/model.py
+++ b/amivapi/studydocs/model.py
@@ -33,7 +33,20 @@ file uploaders have additional permissions:
   user id in the `uploader` field).
 
 - **Admins** can modify items for all users.
+
+<br />
+
+## Summary
+
+TODO(Alex)
 """)
+
+
+class StudyDocValidator(object):
+    """Custom Validator to register `allow_summary` property."""
+
+    def _validate_allow_summary(self, *args, **kwargs):
+        """{'type': 'boolean'}"""
 
 
 studydocdomain = {
@@ -117,7 +130,8 @@ studydocdomain = {
                 'nullable': True,
                 'default': None,
                 'type': 'string',
-                'no_html': True
+                'no_html': True,
+                'allow_summary': True,
             },
 
             'professor': {
@@ -128,7 +142,8 @@ studydocdomain = {
                 'nullable': True,
                 'default': None,
                 'type': 'string',
-                'no_html': True
+                'no_html': True,
+                'allow_summary': True,
             },
             'semester': {
                 'description': 'The Semester for which the course/lecture/... '
@@ -140,6 +155,7 @@ studydocdomain = {
                 'nullable': True,
                 'default': None,
                 'allowed': ['1', '2', '3', '4', '5+'],
+                'allow_summary': True,
 
             },
             'type': {
@@ -148,7 +164,8 @@ studydocdomain = {
                 'nullable': True,
                 'default': None,
                 'allowed': ['exams', 'cheat sheets', 'lecture documents',
-                            'exercises']
+                            'exercises'],
+                'allow_summary': True,
             },
             'course_year': {
                 'type': 'integer',
@@ -157,6 +174,7 @@ studydocdomain = {
                 'default': None,
                 'description': 'The year in which the course *was taken*, '
                                'to separate older from newer files.',
+                'allow_summary': True,
             }
         },
     }

--- a/amivapi/studydocs/summary.py
+++ b/amivapi/studydocs/summary.py
@@ -47,11 +47,11 @@ def _count_distinct(lookup, fieldname):
 def _get_lookup():
     """Get the where clause lookup just like Eve does.
 
-    Unfortunately, Eve onlt parses the `where` at a very low level and does not
+    Unfortunately, Eve only parses the `where` at a very low level and does not
     provide any methods to elegantly access it, so we have use the same
     internal functions as Eve does.
     (Recently, Eve has at least somewhat exposed the parsing, but this
-    code is part of an official release yet [1])
+    code is not part of an official release yet [1])
 
     As soon as there is some 'official' support, this can be removed,
     as it is basically copied, with the abort removed for simplicity

--- a/amivapi/studydocs/summary.py
+++ b/amivapi/studydocs/summary.py
@@ -13,10 +13,7 @@ from eve.io.mongo.parser import parse
 
 
 def add_summary(response):
-    """Add summary to response, if requested."""
-    if request.args.get('summary') is None:
-        return
-
+    """Add summary to response."""
     # Get the where clause to return summary only for matching documents
     lookup = _get_lookup()
 

--- a/amivapi/studydocs/summary.py
+++ b/amivapi/studydocs/summary.py
@@ -7,7 +7,7 @@
 import json
 
 from werkzeug.exceptions import HTTPException
-from flask import current_app, request
+from flask import current_app
 from eve.utils import parse_request
 from eve.io.mongo.parser import parse
 

--- a/amivapi/studydocs/summary.py
+++ b/amivapi/studydocs/summary.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# license: AGPLv3, see LICENSE for details. In addition we strongly encourage
+#          you to buy us beer if we meet and you like the software.
+"""Summarize unique keys to facilitate further studydoc filtering."""
+
+from flask import g, current_app
+
+
+def save_lookup(request, lookup):
+    """Save the current lookup in the requests globals if summary is requested.
+
+    We can only modify the response later, when we don't have easy access
+    to the lookup anymore (but we need it to filter the summary).
+
+    TODO(Alex): `lookup` is only the path parsed by flask, and does not include
+                the `where` query. How to get the actual filter from Eve?
+    """
+    if True:
+        g.saved_lookup = lookup
+    else:
+        g.saved_lookup = None
+
+
+def add_summary(response):
+    """Add summary to response, if requested."""
+    lookup = g.saved_lookup
+    if lookup is None:
+        return
+
+    # Compute distinct values per field (remove fields without any values)
+    summary = {fieldname: _count_distinct(lookup, fieldname)
+               for fieldname in _summary_fields()}
+    response['_summary'] = {k: v for k, v in summary.items() if v}
+
+
+def _summary_fields():
+    return [
+        fieldname for fieldname, schema
+        in current_app.config['DOMAIN']['studydocuments']['schema'].items()
+        if schema.get('allow_summary')
+    ]
+
+
+def _count_distinct(lookup, fieldname):
+    """Use mongodb aggregation to count distinct values."""
+    aggregation = current_app.data.driver.db['studydocuments'].aggregate([
+        {'$match': lookup},
+        {'$group': {'_id': '$' + fieldname, '_count': {'$sum': 1}}},
+    ])
+    return {item['_id']: item['_count'] for item in aggregation
+            if item['_id'] is not None}

--- a/amivapi/tests/studydocs/test_summary.py
+++ b/amivapi/tests/studydocs/test_summary.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+#
+# license: AGPLv3, see LICENSE for details. In addition we strongly encourage
+#          you to buy us beer if we meet and you like the software.
+"""Tests for studydocuments summaries."""
+
+import json
+
+from amivapi.tests.utils import WebTestNoAuth
+
+
+class StudydocsSummaryTest(WebTestNoAuth):
+    """Studycos Test class."""
+
+    def _load_data(self):
+        """Load some test fixtures."""
+        self.load_fixture({
+            'studydocuments': [{
+                'title': 'first',
+                'lecture': 'a',
+                'professor': 'a',
+            }, {
+                'title': 'second',
+                'lecture': 'a',
+                'professor': 'b',
+            }, {
+                'title': 'third',
+                'professor': 'b',
+            }]
+        })
+
+    def test_full_summary(self):
+        """Test returning a summary."""
+        self._load_data()
+
+        response = self.api.get("/studydocuments?summary",
+                                status_code=200).json
+
+        assert '_summary' in response
+        assert response['_summary'] == {
+            'lecture': {
+                'a': 2,
+            },
+            'professor': {
+                'a': 1,
+                'b': 2,
+            }
+        }
+
+    def test_filtered_summary(self):
+        """The summary is only computed for the matched documents."""
+        self._load_data()
+        match = json.dumps({'title': {'$in': ['first', 'second']}})
+
+        response = self.api.get("/studydocuments?where=%s" % match,
+                                status_code=200).json
+
+        assert '_summary' in response
+        assert response['_summary'] == {
+            'lecture': {
+                'a': 2,
+            },
+            'professor': {
+                'a': 1,
+                'b': 1,  # The document with title `third` is ignored
+            }
+        }

--- a/amivapi/tests/studydocs/test_summary.py
+++ b/amivapi/tests/studydocs/test_summary.py
@@ -33,7 +33,7 @@ class StudydocsSummaryTest(WebTestNoAuth):
         """Test returning a summary."""
         self._load_data()
 
-        response = self.api.get("/studydocuments?summary",
+        response = self.api.get("/studydocuments",
                                 status_code=200).json
 
         assert '_summary' in response
@@ -52,7 +52,7 @@ class StudydocsSummaryTest(WebTestNoAuth):
         self._load_data()
         match = json.dumps({'title': {'$in': ['first', 'second']}})
 
-        response = self.api.get("/studydocuments?summary&where=%s" % match,
+        response = self.api.get("/studydocuments?where=%s" % match,
                                 status_code=200).json
 
         assert '_summary' in response
@@ -65,12 +65,3 @@ class StudydocsSummaryTest(WebTestNoAuth):
                 'b': 1,  # The document with title `third` is ignored
             }
         }
-
-    def test_no_default_summary(self):
-        """Test that a summary is only computed if requested."""
-        self._load_data()
-
-        response = self.api.get("/studydocuments",
-                                status_code=200).json
-
-        assert '_summary' not in response

--- a/amivapi/tests/studydocs/test_summary.py
+++ b/amivapi/tests/studydocs/test_summary.py
@@ -52,7 +52,7 @@ class StudydocsSummaryTest(WebTestNoAuth):
         self._load_data()
         match = json.dumps({'title': {'$in': ['first', 'second']}})
 
-        response = self.api.get("/studydocuments?where=%s" % match,
+        response = self.api.get("/studydocuments?summary&where=%s" % match,
                                 status_code=200).json
 
         assert '_summary' in response
@@ -65,3 +65,12 @@ class StudydocsSummaryTest(WebTestNoAuth):
                 'b': 1,  # The document with title `third` is ignored
             }
         }
+
+    def test_no_default_summary(self):
+        """Test that a summary is only computed if requested."""
+        self._load_data()
+
+        response = self.api.get("/studydocuments",
+                                status_code=200).json
+
+        assert '_summary' not in response


### PR DESCRIPTION
Currently, we have a lot of metadata for study docs, but no efficient way to search through it.
In order to provide users a menu to select professors, for example, an application would have to download *all* study documents to learn the possible professors.

On the other hand, this information is much needed, as most students will not know from the top of their head how exactly their professors name might be written or if their lecture can be found as 'Analysis' or 'Analysis I'

This defeats the purpose of filtering study documents with metadata.

Thus, this commit adds the possibility to request a server-side summary of metadata by appending `summary` to the query string, e.g.

```/studydocuments?summary```

The response then contains a new meta field `_summary`, which lists the available values for all meta-data fields along with how many documents are available for them.

```
_summary:
    professor:
        Prof. Dr. Awesome: 10
        Prof. Okay: 5
        ...
    lecture:
        ...
    ...
```

(For sanity reasons, the `author` field is not included in the summary, as most authors will only have a single document and thus the summary would be very large)

The summary is efficiently computed using the MongoDB aggregation framework.
