### PR TITLE
Media validation exception

### DIFF
--- a/amivapi/events/validation.py
+++ b/amivapi/events/validation.py
@@ -37,6 +37,7 @@ class EventValidator(object):
         except json.JSONDecodeError as e:
             self._error(field,
                         "Must be json, parsing failed with exception: %s" % e)
+            return
 
         id_field = current_app.config['ID_FIELD']
         # At this point we have valid JSON, check for event now.

--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -13,7 +13,7 @@ from datetime import timedelta
 
 from passlib.context import CryptContext
 
-VERSION = '2.1.1'
+VERSION = '2.1.2'
 
 # Sentry
 

--- a/amivapi/tests/test_media.py
+++ b/amivapi/tests/test_media.py
@@ -126,25 +126,6 @@ class MediaTest(WebTestNoAuth):
         data = {'test_file': (BytesIO(b'trololo'), "something")}
         self.api.post("/test", data=data, headers=headers, status_code=422)
 
-    def test_validation_error(self):
-        """Check that validation returns proper errors.
-
-        Cerberus does some weird deep copy when reporting errors.
-        With file buffers, this can break as they do not support deepcopy.
-
-        This test is to make sure that the validators don't break cerberus.
-        """
-        headers = {'content-type': 'multipart/form-data'}
-        # Add validator
-        schema = self.app.config['DOMAIN']['test']['schema']
-        schema['test_file']['filetype'] = ['pdf', 'png', 'jpeg']
-
-        data = {'test_file': (BytesIO(b'trololo'), "something")}
-        response = self.api.post("/test", data=data, headers=headers,
-                                 status_code=422).json
-
-        assert 'exception' not in response['_issues']
-
     def test_aspect_ratio_validation(self):
         """Test aspect ratio validation."""
         schema = self.app.config['DOMAIN']['test']['schema']

--- a/amivapi/tests/utils.py
+++ b/amivapi/tests/utils.py
@@ -71,6 +71,14 @@ class TestClient(FlaskClient):
                 "Response:\n%s\n%s\n%s" % (expected_code, status_code,
                                            response, response.data,
                                            response.status))
+        elif ((expected_code == 422) and
+              ('exception' in response.json.get('_issues', {}))):
+            # The validator swallows exceptions and turns them into 'exception'
+            # validation errors. Ensure that tests do not miss this by raising
+            # them properly.
+            error = response.json['_issues']['exception']
+            raise AssertionError("Expected a validation error but the "
+                                 "validator raised an exception: %s" % error)
 
         return response
 

--- a/amivapi/validation.py
+++ b/amivapi/validation.py
@@ -35,6 +35,30 @@ class ValidatorAMIV(Validator):
     online documentation)
     """
 
+    def _error(self, *args, **kwargs):
+        """Fix annoying Cerberus behaviour.
+
+        - Although it never uses it, Cerberus attaches the validated value
+          silently to every error.
+
+        - Whenever Cerberus collects errors, it deepcopies all of them for some
+          reason.
+
+        Now, if the validated value cannot be deepcopied, e.g. incoming file
+        buffers, this causes Cerberus to crash, even though the value is
+        *never* used during error processing.
+
+        Thus, we remove the value from the error and the world is fine again.
+        Luckily, Cerberus keeps a reference to the most recent created error,
+        so we at least have a way to do that.
+
+        See here:
+        https://github.com/pyeve/cerberus/blob/master/cerberus/validator.py#L232
+        """
+        super()._error(*args, **kwargs)
+        if hasattr(self, 'recent_error') and self.recent_error is not None:
+            self.recent_error.value = None
+
     def _validate_title(*_):
         """{'type': 'string'}"""
 


### PR DESCRIPTION
I have noticed that Cerberus swallows exceptions.
I modified the test framework to detect this.

This showed two errors in our validators. One was a missing
return statement, the other was more fundamental:

Whenever a file validator would register an error, Cerberus
would crash, as it internally saved the validated value
and for some reason deepcopies it during the processing.
File buffers couldn't be deepcopied, causing a crash.

I have solved this by removed the reference to the validated
value, as it is *never* used anyways.
(I have no clue why it is in there in the first place)