### PR TITLE
Use correct ratio (portrait) for event posters, update docs.

### DIFF
--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -28,8 +28,8 @@ versions should be included.
 ## Images
 
 While the API generally accepts both `form-data` and JSON-input,
-JSON cannot be used to upload event images.
-You must use [`multipart/form-data`][1] to be able to send files.
+images can only be send using [`multipart/form-data`][1]. There's a quick
+how-to on sending data in the [cheatsheet](#section/Cheatsheet/Sending-Data).
 
 [1]: https://www.w3.org/TR/html5/sec-forms.html#multipart-form-data
 
@@ -273,7 +273,7 @@ eventdomain = {
                 'title': 'Infoscreen Image',
                 'description': 'Event advertisement image to display on the '
                                'infoscreen. Must have an aspect ratio of '
-                               '16:9. (`.jpeg` or `.png`)',
+                               '16:9 (width:height). (`.jpeg` or `.png`)',
 
                 'filetype': ['png', 'jpeg'],
                 'type': 'media',
@@ -284,14 +284,15 @@ eventdomain = {
             'img_poster': {
                 'title': 'Poster',
                 'description': 'Event advertisement image for printed posters.'
-                               'Must have an aspect_ratio of 1.41:1, i.e. '
-                               'the DIN A aspect ratio. (`.jpeg` or `.png`)',
+                               'Must have an aspect_ratio of 1:1.41 '
+                               '(width:height), i.e. the DIN A aspect ratio. '
+                               '(`.jpeg` or `.png`)',
 
                 'filetype': ['png', 'jpeg'],
                 'type': 'media',
                 'nullable': True,
                 'default': None,
-                'aspect_ratio': (1.41, 1),  # DIN A aspect ratio
+                'aspect_ratio': (1, 1.41),  # DIN A aspect ratio
             },
             'img_thumbnail': {
                 'title': 'Thumbnail',

--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -28,7 +28,7 @@ versions should be included.
 ## Images
 
 While the API generally accepts both `form-data` and JSON-input,
-images can only be send using [`multipart/form-data`][1]. There's a quick
+images can only be sent using [`multipart/form-data`][1]. There's a quick
 how-to on sending data in the [cheatsheet](#section/Cheatsheet/Sending-Data).
 
 [1]: https://www.w3.org/TR/html5/sec-forms.html#multipart-form-data

--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -13,7 +13,11 @@ from datetime import timedelta
 
 from passlib.context import CryptContext
 
+<<<<<<< HEAD
 VERSION = '2.1.3'
+=======
+VERSION = '2.1.4'
+>>>>>>> Use correct ratio (portrait) for event posters, update docs.
 
 # Sentry
 

--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -13,11 +13,7 @@ from datetime import timedelta
 
 from passlib.context import CryptContext
 
-<<<<<<< HEAD
-VERSION = '2.1.3'
-=======
 VERSION = '2.1.4'
->>>>>>> Use correct ratio (portrait) for event posters, update docs.
 
 # Sentry
 


### PR DESCRIPTION
We specified the aspect ratio as height:width, but validate it width:height, which I now corrected.

While at it, I improved the respective docs a little.