### PR TITLE
change cents to rappen

### DIFF
--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -233,7 +233,7 @@ eventdomain = {
                 'no_html': True,
             },
             'price': {
-                'description': 'Price in *Cents*, e.g. '
+                'description': 'Price in *Rappen*, e.g. '
                                '1000 for 10 CHF.',
                 'example': None,
 

--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -13,7 +13,7 @@ from datetime import timedelta
 
 from passlib.context import CryptContext
 
-VERSION = '2.1.4'
+VERSION = '2.1.5'
 
 # Sentry
 


### PR DESCRIPTION
The description text with 'cents' is more confusing than helpful to users.