### PR TITLE
Fix home link methods

### DIFF
--- a/amivapi/auth/auth.py
+++ b/amivapi/auth/auth.py
@@ -140,9 +140,10 @@ class AmivTokenAuth(BasicAuth):
 
         Returns:
             dict: The filter, will be combined with other filters in the hook.
-                Return None or empty dict if no filters should be applied.
+                Return empty dict if no filters should be applied.
+                Return None if no lookup should be possible at for the user.
         """
-        return None
+        return {}
 
 
 class AdminOnlyAuth(AmivTokenAuth):
@@ -153,7 +154,7 @@ class AdminOnlyAuth(AmivTokenAuth):
         Therefore no results should be given. To give a more precise error
         message, we abort. Otherwise normal users would just see an empty list.
         """
-        abort(403)
+        return None
 
 
 # Decorators that will only call a function if auth conditions are met
@@ -308,6 +309,9 @@ def abort_if_not_public(*args):
 def add_lookup_filter(auth, resource, request, lookup):
     """Get and add lookup filter for GET, PATCH and DELETE."""
     extra_lookup = auth.create_user_lookup_filter(g.current_user)
+
+    if extra_lookup is None:
+        abort(403)  # No lookup at all
 
     if extra_lookup:
         # Add the additional lookup with an `$and` condition

--- a/amivapi/auth/auth.py
+++ b/amivapi/auth/auth.py
@@ -141,7 +141,7 @@ class AmivTokenAuth(BasicAuth):
         Returns:
             dict: The filter, will be combined with other filters in the hook.
                 Return empty dict if no filters should be applied.
-                Return None if no lookup should be possible at for the user.
+                Return None if no lookup should be possible for the user.
         """
         return {}
 

--- a/amivapi/auth/link_methods.py
+++ b/amivapi/auth/link_methods.py
@@ -43,13 +43,13 @@ def _get_resource_methods(resource):
     if 'GET' in methods:
         methods += ['HEAD']
 
-    # resources may not have public read access, but we still can see the
-    # resource on the home endpoint
-    if user or is_admin or g.get('resource_admin_readonly'):
+    # read for users/admins
+    user_read = user and (auth.create_user_lookup_filter(user) is not None)
+    if user_read or is_admin or g.get('resource_admin_readonly'):
         methods += ['GET', 'HEAD']
 
-    # write methods
-    if is_admin or auth.has_resource_write_permission(user):
+    # write for users/admins
+    if is_admin or (user and auth.has_resource_write_permission(user)):
         methods += res['resource_methods']
 
     # Remove duplicates

--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -138,8 +138,8 @@ eventdomain = {
         'resource_methods': ['GET', 'POST'],
         'item_methods': ['GET', 'PATCH', 'DELETE'],
 
-        'public_methods': ['GET'],
-        'public_item_methods': ['GET'],
+        'public_methods': ['GET', 'HEAD'],
+        'public_item_methods': ['GET', 'HEAD'],
 
         'schema': {
             'title_de': {

--- a/amivapi/joboffers/__init__.py
+++ b/amivapi/joboffers/__init__.py
@@ -38,8 +38,8 @@ jobdomain = {
         'resource_methods': ['GET', 'POST'],
         'item_methods': ['GET', 'PATCH', 'DELETE'],
 
-        'public_item_methods': ['GET'],
-        'public_methods': ['GET'],
+        'public_item_methods': ['GET', 'HEAD'],
+        'public_methods': ['GET', 'HEAD'],
 
         'schema': {
             'company': {

--- a/amivapi/tests/auth/test_auth.py
+++ b/amivapi/tests/auth/test_auth.py
@@ -53,7 +53,7 @@ class AmivTokenAuthTest(WebTest):
     def test_amiv_token_auth_create_user_lookup_filter(self):
         """Test default lookup filter. Should be None."""
         auth = AmivTokenAuth()
-        self.assertIsNone(auth.create_user_lookup_filter(None))
+        self.assertEquals(auth.create_user_lookup_filter(None), {})
 
     def test_amiv_token_auth_has_item_write_permission(self):
         """Test default write permission. Should be False."""

--- a/amivapi/tests/auth/test_link_methods.py
+++ b/amivapi/tests/auth/test_link_methods.py
@@ -336,6 +336,9 @@ class LinkIntegrationTest(WebTest):
 
     Not using any fake auth classes here, we will just look at the users
     resource and home endpoint to check the results.
+
+    For the home endpoint, we test that all reported methods work, and
+    all unreported do not.
     """
 
     def setUp(self):
@@ -357,23 +360,35 @@ class LinkIntegrationTest(WebTest):
             if links['href'] == 'users':
                 return links['methods']
 
+    def test_allowed(self, **args):
+        """Test that the allowed methods works, and all others do not."""
+        home_response = self.api.get("/", status_code=200, **args)
+        for link in home_response.json['_links']['child']:
+            # options are always allowed
+            self.assertIn('OPTIONS', link['methods'])
+
+            resource = link['href']
+            allowed_methods = link['methods']
+            all_methods = ['get', 'head', 'options', 'post', 'patch', 'delete']
+
+            for method in all_methods:
+                response = getattr(self.api, method)(resource, **args)
+                if method.upper() in allowed_methods:
+                    self.assertNotIn(response.status_code, [401, 403, 405])
+                else:
+                    self.assertIn(response.status_code, [401, 403, 405])
+
     def test_home_public(self):
         """Test GET on home for public user."""
-        response = self.api.get("/", status_code=200)
-        self.assertItemsEqual(self.get_user_methods(response),
-                              ['OPTIONS'])
+        self.test_allowed()
 
     def test_home_registered(self):
         """Test GET on home for a registered user."""
-        response = self.api.get("/", token=self.user_token, status_code=200)
-        self.assertItemsEqual(self.get_user_methods(response),
-                              ['OPTIONS', 'GET', 'HEAD'])
+        self.test_allowed(token=self.user_token)
 
     def test_home_admin(self):
         """Test GET on home for an admin."""
-        response = self.api.get("/", token=self.root_token, status_code=200)
-        self.assertItemsEqual(self.get_user_methods(response),
-                              ['OPTIONS', 'GET', 'HEAD', 'POST'])
+        self.test_allowed(token=self.root_token)
 
     def test_resource_registered(self):
         """Test GET on resource for a registered user."""

--- a/amivapi/tests/auth/test_link_methods.py
+++ b/amivapi/tests/auth/test_link_methods.py
@@ -360,9 +360,9 @@ class LinkIntegrationTest(WebTest):
             if links['href'] == 'users':
                 return links['methods']
 
-    def test_allowed(self, **args):
+    def check_link_methods(self, token):
         """Test that the allowed methods works, and all others do not."""
-        home_response = self.api.get("/", status_code=200, **args)
+        home_response = self.api.get("/", status_code=200, token=token)
         for link in home_response.json['_links']['child']:
             # options are always allowed
             self.assertIn('OPTIONS', link['methods'])
@@ -372,7 +372,7 @@ class LinkIntegrationTest(WebTest):
             all_methods = ['get', 'head', 'options', 'post', 'patch', 'delete']
 
             for method in all_methods:
-                response = getattr(self.api, method)(resource, **args)
+                response = getattr(self.api, method)(resource, token=token)
                 if method.upper() in allowed_methods:
                     self.assertNotIn(response.status_code, [401, 403, 405])
                 else:
@@ -380,15 +380,15 @@ class LinkIntegrationTest(WebTest):
 
     def test_home_public(self):
         """Test GET on home for public user."""
-        self.test_allowed()
+        self.check_link_methods(None)
 
     def test_home_registered(self):
         """Test GET on home for a registered user."""
-        self.test_allowed(token=self.user_token)
+        self.check_link_methods(self.user_token)
 
     def test_home_admin(self):
         """Test GET on home for an admin."""
-        self.test_allowed(token=self.root_token)
+        self.check_link_methods(self.root_token)
 
     def test_resource_registered(self):
         """Test GET on resource for a registered user."""

--- a/amivapi/users/security.py
+++ b/amivapi/users/security.py
@@ -76,7 +76,7 @@ class UserAuth(AmivTokenAuth):
             return {'_id': user_id}
         else:
             # Can see everyone (fields will be filtered later)
-            return None
+            return {}
 
 
 @on_post_hook


### PR DESCRIPTION
For the home endpoint, some link methods were incorrect, i.e. the API would report that some methods are allowed for the current user (although they were not) and some of the reported methods would not be allowed.

This was the result of to unrelated problems:

1. Not allowed `HEAD`: Eve automatically allows `HEAD` requests if `GET` is possible. However, if `GET` is set to `public_methods`, `HEAD` *is not* automatically included, and has to be set explicitly. Unaware of this, the API would report that `HEAD` is allowed, while it was not. I have corrected the respective resource configs such that `HEAD` is allowed whenever `GET` is, as it is intended.

2. Allowed `GET` if it is not: Some resources using `AdminOnlyAuth` would not create a user lookup filter, but instead `abort`. The API had no way to check this properly, and would report that `GET` is possible (even if it would be aborted. I have changed the output of creating a lookup filter such that not allowing *any* lookup for a user can be properly returned. Now the API can correctly determine whether `GET` is possible or not.

Aside from that, I improved the tests for links on `/` to actually test all reported methods.

Closes #343.