### PR TITLE
Fix token in email

### DIFF
--- a/amivapi/events/emails.py
+++ b/amivapi/events/emails.py
@@ -6,7 +6,6 @@
 
 Needed when external users want to sign up for public events.
 """
-from base64 import b64decode, b64encode
 from bson import ObjectId
 from eve.methods.delete import deleteitem_internal
 from eve.methods.patch import patch_internal

--- a/amivapi/events/emails.py
+++ b/amivapi/events/emails.py
@@ -37,7 +37,7 @@ def send_confirmmail_to_unregistered_users(items):
                 title = event['title_de']
 
             token = Signer(get_token_secret()).sign(
-                str(item['_id']).encode('utf-8'))
+                str(item['_id']).encode('utf-8')).decode('utf-8')
 
             if current_app.config.get('SERVER_NAME') is None:
                 current_app.logger.warning("SERVER_NAME is not set. E-Mail "

--- a/amivapi/events/emails.py
+++ b/amivapi/events/emails.py
@@ -6,11 +6,12 @@
 
 Needed when external users want to sign up for public events.
 """
+from base64 import b64decode, b64encode
 from bson import ObjectId
 from eve.methods.delete import deleteitem_internal
 from eve.methods.patch import patch_internal
 from flask import Blueprint, current_app, redirect, url_for
-from itsdangerous import BadSignature, Signer
+from itsdangerous import BadSignature, URLSafeSerializer
 
 from amivapi.events.queue import update_waiting_list
 from amivapi.events.utils import get_token_secret
@@ -36,8 +37,8 @@ def send_confirmmail_to_unregistered_users(items):
             else:
                 title = event['title_de']
 
-            token = Signer(get_token_secret()).sign(
-                str(item['_id']).encode('utf-8')).decode('utf-8')
+            s = URLSafeSerializer(get_token_secret())
+            token = s.dumps(str(item['_id']))
 
             if current_app.config.get('SERVER_NAME') is None:
                 current_app.logger.warning("SERVER_NAME is not set. E-Mail "
@@ -74,8 +75,8 @@ def on_confirm_email(token):
     We try to confirm the specified signup and redirect to a webpage.
     """
     try:
-        s = Signer(get_token_secret())
-        signup_id = ObjectId(s.unsign(token).decode('utf-8'))
+        s = URLSafeSerializer(get_token_secret())
+        signup_id = ObjectId(s.loads(token))
     except BadSignature:
         return "Unknown token"
 
@@ -101,8 +102,8 @@ def on_confirm_email(token):
 def on_delete_signup(token):
     """Endpoint to delete signups via email"""
     try:
-        s = Signer(get_token_secret())
-        signup_id = ObjectId(s.unsign(token).decode('utf-8'))
+        s = URLSafeSerializer(get_token_secret())
+        signup_id = ObjectId(s.loads(token))
     except BadSignature:
         return "Unknown token"
 

--- a/amivapi/events/queue.py
+++ b/amivapi/events/queue.py
@@ -74,7 +74,7 @@ def notify_signup_accepted(event_name, signup):
         email = signup['email']
 
     token = Signer(get_token_secret()).sign(
-        str(signup[id_field]).encode('utf-8'))
+        str(signup[id_field]).encode('utf-8')).decode('utf-8')
 
     if current_app.config.get('SERVER_NAME') is None:
         current_app.logger.warning("SERVER_NAME is not set. E-Mail links "

--- a/amivapi/events/queue.py
+++ b/amivapi/events/queue.py
@@ -5,7 +5,7 @@
 """Logic to implement different signup queues."""
 
 from flask import current_app, url_for
-from itsdangerous import Signer
+from itsdangerous import URLSafeSerializer
 from pymongo import ASCENDING
 
 from amivapi.utils import mail
@@ -73,8 +73,8 @@ def notify_signup_accepted(event_name, signup):
         name = 'Guest of AMIV'
         email = signup['email']
 
-    token = Signer(get_token_secret()).sign(
-        str(signup[id_field]).encode('utf-8')).decode('utf-8')
+    s = URLSafeSerializer(get_token_secret())
+    token = s.dumps(str(signup[id_field]))
 
     if current_app.config.get('SERVER_NAME') is None:
         current_app.logger.warning("SERVER_NAME is not set. E-Mail links "


### PR DESCRIPTION
The email tests failed because the token could not be decoded. This PR fixes this.

The tokens were returned as bytes, and for some reason, the `url_for` that turns the token into
a clickable link would take the `b'...'` and apply some escaping, resulting in `b%27...%27`.
This is not intended, the tokens should be included as utf-8 strings in the link.

I'm not quite sure why the tests did not fail before, but now everything is working as intended.