### PR TITLE
Fix issue 348 (semicolons between characters of To email address)

### DIFF
--- a/amivapi/utils.py
+++ b/amivapi/utils.py
@@ -94,7 +94,7 @@ def mail(sender, to, subject, text):
         msg = MIMEText(text)
         msg['Subject'] = subject
         msg['From'] = sender
-        msg['To'] = ';'.join(to if isinstance(to, list) else [to])
+        msg['To'] = ';'.join([to] if isinstance(to, str) else to)
 
         try:
             with smtplib.SMTP(config.SMTP_SERVER,

--- a/amivapi/utils.py
+++ b/amivapi/utils.py
@@ -94,7 +94,7 @@ def mail(sender, to, subject, text):
         msg = MIMEText(text)
         msg['Subject'] = subject
         msg['From'] = sender
-        msg['To'] = ';'.join(to)
+        msg['To'] = ';'.join(to if isinstance(to, list) else [to])
 
         try:
             with smtplib.SMTP(config.SMTP_SERVER,


### PR DESCRIPTION
check if argument is a string or a list of strings. If it is a string convert to [string]