### PR TITLE
Signup count split between accepted and unaccepted

### DIFF
--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -451,7 +451,16 @@ eventdomain = {
             },
 
             'signup_count': {
-                'description': 'Current number of singups',
+                'description': 'Current number of accepted singups.',
+
+                'readonly': True,
+                'type': 'integer'
+            },
+
+            'unaccepted_count': {
+                'description': 'Current number of unaccepted singups. This may'
+                               ' either be participants on the waiting list '
+                               'or unconfirmed email signups.',
 
                 'readonly': True,
                 'type': 'integer'

--- a/amivapi/events/projections.py
+++ b/amivapi/events/projections.py
@@ -41,7 +41,9 @@ def add_signup_count_to_event(item):
     """After an event is fetched from the database we add the current signup
     count"""
     item['signup_count'] = current_app.data.driver.db['eventsignups'].find(
-        {'event': item['_id']}).count()
+        {'event': item['_id'], 'accepted': True}).count()
+    item['unaccepted_count'] = current_app.data.driver.db['eventsignups'].find(
+        {'event': item['_id'], 'accepted': False}).count()
 
 
 def add_signup_count_to_event_collection(items):


### PR DESCRIPTION
The `signup_count` was introduced such that people who do not see the signups know whether an event is full or not. However, so far also unaccepted signups are counted in, contradicting it's purpose.

With this PR we split between unaccepted and accepted signups. Fixes #364 