### PR TITLE
Improve mail function

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,14 @@ MONGO_PASSWORD = 'amivapi'
 # REMOTE_MAILING_LIST_DIR = './'
 
 # SMTP configuration for mails sent by AMIVAPI (optional)
-# API_MAIL = 'api@amiv.ethz.ch'
 # SMTP_SERVER = 'localhost'
 # SMTP_PORT = '587'
 # SMTP_USERNAME = ''
 # SMTP_PASSWORD = ''
+
+# Mail configuration (`{subject}` is a placeholder, filled by the API)
+# API_MAIL = 'api@amiv.ethz.ch'
+# API_MAIL_SUBJECT = '[AMIV] {subject}'
 
 # Allow accessing a list of newsletter subscribers at /newslettersubscribers
 # SUBSCRIBER_LIST_USERNAME = ''

--- a/amivapi/events/emails.py
+++ b/amivapi/events/emails.py
@@ -36,8 +36,8 @@ def notify_signup_accepted(event, signup):
     deletion_link = url_for('emails.on_delete_signup', token=token,
                             _external=True)
 
-    mail(current_app.config['API_MAIL'], [email],
-         'AMIV Eventsignup accepted',
+    mail([email],
+         'Eventsignup accepted',
          current_app.config['ACCEPT_EMAIL_TEXT'].format(
              name=name,
              title=event.get('title_en') or event.get('title_de'),
@@ -69,8 +69,8 @@ def send_confirmmail_to_unregistered_users(items):
             confirm_link = url_for('emails.on_confirm_email', token=token,
                                    _external=True)
 
-            mail(current_app.config['API_MAIL'], [item['email']],
-                 'Registration for AMIV event %s' % title,
+            mail([item['email']],
+                 'Registration for %s' % title,
                  current_app.config['CONFIRM_EMAIL_TEXT'].format(
                      title=title,
                      link=confirm_link))

--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -65,6 +65,7 @@ REMOTE_MAILING_LIST_DIR = './'  # Use home directory on remote by default
 
 # SMTP server defaults
 API_MAIL = 'api@amiv.ethz.ch'
+API_MAIL_SUBJECT_PREFIX = "[AMIV]"
 SMTP_HOST = 'localhost'
 SMTP_PORT = 587
 SMTP_TIMEOUT = 10

--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -65,7 +65,7 @@ REMOTE_MAILING_LIST_DIR = './'  # Use home directory on remote by default
 
 # SMTP server defaults
 API_MAIL = 'api@amiv.ethz.ch'
-API_MAIL_SUBJECT_PREFIX = "[AMIV]"
+API_MAIL_SUBJECT = "[AMIV] {subject}"
 SMTP_HOST = 'localhost'
 SMTP_PORT = 587
 SMTP_TIMEOUT = 10

--- a/amivapi/utils.py
+++ b/amivapi/utils.py
@@ -78,7 +78,7 @@ def mail(to, subject, text):
     """Send a mail to a list of recipients.
 
     The mail is sent from the address specified by `API_MAIL` in the config,
-    and the subject is prefixed by `API_MAIL_SUBJECT_PREFIX`.
+    and the subject formatted according to `API_MAIL_SUBJECT`.
 
 
     Args:
@@ -87,7 +87,7 @@ def mail(to, subject, text):
         text(string): Mail content
     """
     sender = app.config['API_MAIL']
-    subject = " ".join((app.config['API_MAIL_SUBJECT_PREFIX'], subject))
+    subject = app.config['API_MAIL_SUBJECT'].format(subject=subject)
 
     if app.config.get('TESTING', False):
         app.test_mails.append({

--- a/amivapi/utils.py
+++ b/amivapi/utils.py
@@ -74,15 +74,21 @@ def get_id(item):
         return ObjectId(item['_id'])
 
 
-def mail(sender, to, subject, text):
+def mail(to, subject, text):
     """Send a mail to a list of recipients.
 
+    The mail is sent from the address specified by `API_MAIL` in the config,
+    and the subject is prefixed by `API_MAIL_SUBJECT_PREFIX`.
+
+
     Args:
-        from(string): From address
         to(list of strings): List of recipient addresses
         subject(string): Subject string
         text(string): Mail content
     """
+    sender = app.config['API_MAIL']
+    subject = " ".join((app.config['API_MAIL_SUBJECT_PREFIX'], subject))
+
     if app.config.get('TESTING', False):
         app.test_mails.append({
             'subject': subject,


### PR DESCRIPTION
All API mails are sent from the same address, thus the `mail` util
does not require a sender mail anymore, and instead always uses
the API mail from the config.

Additionally, the mail function now adds an configurable prefix
to the mail subject, e.g. "[AMIV]", to increase consistency and
allow users to spot API mails quickly.