### PR TITLE
Increment version number.

### DIFF
--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -13,7 +13,7 @@ from datetime import timedelta
 
 from passlib.context import CryptContext
 
-VERSION = '2.1.5'
+VERSION = '2.2.0'
 
 # Sentry
 


### PR DESCRIPTION
During the coding weekend, I forgot to enforce incrementing the version
number in each pull request. However, for useful error reports in Sentry,
the version number is important.

This commit set the API to a 'post-codingweekend' version.