### PR TITLE
Push Eve to 0.8.2 (dev branch for now).

### DIFF
--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -13,7 +13,7 @@ from datetime import timedelta
 
 from passlib.context import CryptContext
 
-VERSION = '2.2.0'
+VERSION = '2.2.1'
 
 # Sentry
 

--- a/amivapi/utils.py
+++ b/amivapi/utils.py
@@ -311,7 +311,13 @@ def on_post_hook(func):
         """This is the hook eve will see."""
         response = args[-1]
         if response.status_code in range(200, 300):
-            payload = json.loads(response.get_data(as_text=True))
-            func(*args, payload)
-            response.set_data(json.dumps(payload))
+            try:
+                payload = json.loads(response.get_data(as_text=True))
+                func(*args, payload)
+                response.set_data(json.dumps(payload))
+            except RuntimeError:
+                # If we are in passthrough mode, e.g. for sending files,
+                # Eve is just passing through data and modifying the payload
+                # is not possible
+                pass
     return wrapped

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
-eve==0.8
+# Eve 0.8.2 fixes an important bug, enabling CORS for the /media endpoint,
+# which we require. As it is not released, we currently use the github branch.
+# As soon as 0.8.2. is released, we can switch back.
+#eve==0.8.2
+-e git+https://github.com/pyeve/eve.git@48d9c25cdca04c2f5a31ce01a1310d493fc67eda#egg=Eve
 -e git+https://github.com/hermannsblum/eve-swagger.git@5c9cf066ffa72712f9018a3eb0c5142f7733d8cc#egg=Eve_Swagger
 -e git+https://github.com/NotSpecial/nethz.git@1d3004081c3618f1f41463476a847b0bddd6d91a#egg=nethz
 passlib==1.6.5


### PR DESCRIPTION
For editing file lists comfortably, in particular to replace single files, clients need to download all files, as Eve currently accepts only the list as a whole for patches, i.e. single items cannot be replaced without sending all others.

Downloading the files in javascript is currently impossible, as Eve does not supply the needed CORS headers to the media endpoint. Eve 0.8.2 fixes this, but is not yet released.

As file list editing of significant importance for the new amiv website (for studydocs), we have decided to switch to the currentl development branch of Eve. We can switch back to pypi as soon as 0.8.2. is released.

Aside from that, Eve made some internal changes to the response class, which required an update to one of our hooks for the case of file passthrough.