### PR TITLE
Don't install dependencies in editable mode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@
 # which we require. As it is not released, we currently use the github branch.
 # As soon as 0.8.2. is released, we can switch back.
 #eve==0.8.2
--e git+https://github.com/pyeve/eve.git@48d9c25cdca04c2f5a31ce01a1310d493fc67eda#egg=Eve
--e git+https://github.com/hermannsblum/eve-swagger.git@5c9cf066ffa72712f9018a3eb0c5142f7733d8cc#egg=Eve_Swagger
--e git+https://github.com/NotSpecial/nethz.git@1d3004081c3618f1f41463476a847b0bddd6d91a#egg=nethz
+git+https://github.com/pyeve/eve.git@48d9c25cdca04c2f5a31ce01a1310d493fc67eda#egg=Eve
+git+https://github.com/hermannsblum/eve-swagger.git@5c9cf066ffa72712f9018a3eb0c5142f7733d8cc#egg=Eve_Swagger
+git+https://github.com/NotSpecial/nethz.git@1d3004081c3618f1f41463476a847b0bddd6d91a#egg=nethz
 passlib==1.6.5
 jsonschema==2.5.1
 click==6.6


### PR DESCRIPTION
We added this to make it easier to insert print statements into our dependencies or do other code changes for testing. We don't want this in production and it is simple to readd it for debugging if needed.