### PR TITLE
Fix typo in resource definition for joboffers

### DIFF
--- a/amivapi/joboffers/__init__.py
+++ b/amivapi/joboffers/__init__.py
@@ -62,7 +62,7 @@ jobdomain = {
 
             'title_de': {
                 'title': 'German Title',
-                'description': 'The title of the job offer. ',
+                'description': 'The title of the job offer in German.',
                 'example': 'Rest API Entwickler (100%)',
 
                 'type': 'string',
@@ -74,8 +74,8 @@ jobdomain = {
                 'default': None,
             },
             'title_en': {
-                'title': 'German Title',
-                'description': 'The title of the job offer. ',
+                'title': 'English Title',
+                'description': 'The title of the job offer in English.',
                 'example': 'Rest API Developer (100%)',
 
                 'type': 'string',


### PR DESCRIPTION
The name of the English title field was the same as for the German one. As this terms are used to generate the form for the Admintool, it should state the correct language.