### PR TITLE
Allow proper caching with `If-Modified-Since`.

### DIFF
--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -41,7 +41,7 @@ X_DOMAINS = '*'
 X_HEADERS = ['Authorization', 'Content-Type', 'Cache-Control',
              'If-Match', 'If-None-Match', 'If-Modified-Since']
 MONGO_QUERY_BLACKLIST = ['$where']  # default blacklists where and regex queries
-CACHE_CONTROL = 'no-store, must-revalidate'
+CACHE_CONTROL = 'no-cache, must-revalidate'
 
 # MongoDB
 MONGO_HOST = 'localhost'


### PR DESCRIPTION
There is a subtle difference between `no-store` and `no-cache`.

`no-store`: Never return from cache, always request new. (Especially problematic for images, which are always re-loaded.) **This is what we currently have**.

`no-cache`: Don't return from cache by default, but first re-validate with the server, in our case using the `If-Modified-Since` header, which browsers use automatically, as eve includes `Last-Modified` headers in all responses. **This is what we actually want.**

Thus, with this small change, the api should cache in the way we want. Stale results from cache will never be returned without a request, and data is only transmitted if anything has changed.

More info: https://www.keycdn.com/blog/http-cache-headers

Note: Having both `no-cache` and `must-revalidate` doesn't actually do anything, as each on it's own would be enough for what we want, but for compatibility its probably best to keep both.

Closes #389