### PR TITLE
Update requirements and test setup.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,6 @@ Dockerfile.test
 run_tests.sh
 
 # Byte-compiled / optimized / DLL files
-__pycache__/
 **/__pycache__/
 *.py[cod]
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@ run_tests.sh
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
+**/__pycache__/
 *.py[cod]
 
 # Editor backups

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.6-alpine3.9
 
 # Create user with home directory and no password and change workdir.
 RUN adduser -Dh /api amivapi

--- a/amivapi/auth/apikeys.py
+++ b/amivapi/auth/apikeys.py
@@ -125,7 +125,7 @@ apikeydomain = {
                 'type': 'dict',
                 'keyschema': {'type': 'string',
                               'api_resources': True},
-                'valueschema': {'type': 'string',
+                'valuesrules': {'type': 'string',
                                 'allowed': ['read', 'readwrite']},
                 'required': True,
             }

--- a/amivapi/events/validation.py
+++ b/amivapi/events/validation.py
@@ -9,7 +9,6 @@ import json
 
 from flask import current_app, g, request
 from jsonschema import Draft4Validator, SchemaError
-import pytz
 
 
 class EventValidator(object):
@@ -114,11 +113,11 @@ class EventValidator(object):
 
             # The event has signup, check if it is open
             if not g.get('resource_admin'):
-                now = datetime.now(pytz.utc)
-                if now < event['time_register_start']:
+                now = datetime.utcnow()
+                if now < event['time_register_start'].replace(tzinfo=None):
                     self._error(field, "the signup for event with %s is "
                                 "not open yet." % event_id)
-                elif now > event['time_register_end']:
+                elif now > event['time_register_end'].replace(tzinfo=None):
                     self._error(field, "the signup for event with id %s "
                                 "closed." % event_id)
 

--- a/amivapi/groups/model.py
+++ b/amivapi/groups/model.py
@@ -318,7 +318,7 @@ groupdomain = {
                 'type': 'dict',
                 'keyschema': {'type': 'string',
                               'api_resources': True},
-                'valueschema': {'type': 'string',
+                'valuesrules': {'type': 'string',
                                 'allowed': ['read', 'readwrite']},
                 'nullable': True,
                 'default': None,

--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -82,12 +82,7 @@ ROOT_PASSWORD = u"root"  # Will be overwridden by config.py
 SESSION_TIMEOUT = timedelta(days=365)
 PASSWORD_CONTEXT = CryptContext(
     schemes=["pbkdf2_sha256"],
-
-    # default_rounds is used when hashing new passwords, to be varied each
-    # time by vary_rounds
     pbkdf2_sha256__default_rounds=10 ** 3,
-    pbkdf2_sha256__vary_rounds=0.1,
-
     # min_rounds is used to determine if a hash needs to be upgraded
     pbkdf2_sha256__min_rounds=8 * 10 ** 2,
 )

--- a/amivapi/tests/auth/test_auth.py
+++ b/amivapi/tests/auth/test_auth.py
@@ -297,7 +297,7 @@ class AuthFunctionTest(FakeAuthTest):
         ]
 
         # Put into db
-        collection.insert(data)
+        collection.insert_many(data)
 
         for session in data:
             with self.app.test_request_context(

--- a/amivapi/tests/auth/test_sessions.py
+++ b/amivapi/tests/auth/test_sessions.py
@@ -184,8 +184,7 @@ class PasswordVerificationTest(WebTest):
         Also needs app context to access config.
         """
         with self.app.app_context():
-            hashed = self.app.config['PASSWORD_CONTEXT'].encrypt(
-                "some_pw")
+            hashed = self.app.config['PASSWORD_CONTEXT'].hash("some_pw")
 
             # Correct password
             self.assertTrue(
@@ -205,11 +204,9 @@ class PasswordVerificationTest(WebTest):
         weak_context = CryptContext(
             schemes=["pbkdf2_sha256"],
             pbkdf2_sha256__default_rounds=5,
-            pbkdf2_sha256__vary_rounds=0.1,
-            pbkdf2_sha256__min_rounds=1,
         )
 
-        return weak_context.encrypt(plaintext)
+        return weak_context.hash(plaintext)
 
     def assertRehashed(self, user_id, plaintext, old_hash):
         """Assert that the password was rehased.
@@ -244,9 +241,7 @@ class PasswordVerificationTest(WebTest):
             weak_hash = self._get_weak_hash(password)
 
             # Add a user with to db. use password hashed with weak context
-            user_id = db.insert({
-                'password': weak_hash
-            })
+            user_id = db.insert_one({'password': weak_hash}).inserted_id
 
             user = db.find_one({'_id': ObjectId(user_id)})
 
@@ -262,9 +257,7 @@ class PasswordVerificationTest(WebTest):
         weak_hash = self._get_weak_hash(password)
 
         # Add a user with to db. use password hashed with weak context
-        user_id = db.insert({
-            'password': weak_hash
-        })
+        user_id = db.insert_one({'password': weak_hash}).inserted_id
 
         login_data = {
             'username': str(user_id),

--- a/amivapi/tests/fixtures.py
+++ b/amivapi/tests/fixtures.py
@@ -50,7 +50,6 @@ from contextlib import contextmanager
 
 from bson import ObjectId
 from eve.methods.post import post_internal
-import pytz
 from werkzeug.datastructures import FileStorage
 
 from amivapi.settings import EMAIL_REGEX, REDIRECT_URI_REGEX
@@ -209,7 +208,7 @@ class FixtureMixin(object):
             # Create some random permission
             resource = random.choice(list(self.app.config['DOMAIN'].keys()))
             permission = (
-                random.choice(schema['permissions']['valueschema']['allowed']))
+                random.choice(schema['permissions']['valuesrules']['allowed']))
 
             obj['permissions'] = {resource: permission}
 
@@ -240,10 +239,10 @@ class FixtureMixin(object):
 
         # fullfill earlier_than and later_than validators
         obj['time_advertising_start'] = (
-            datetime.now(pytz.utc) - timedelta(
+            datetime.utcnow() - timedelta(
                 seconds=random.randint(0, 1000000)))
         obj['time_advertising_end'] = (
-            datetime.now(pytz.utc) + timedelta(
+            datetime.utcnow() + timedelta(
                 seconds=random.randint(0, 1000000)))
 
         # add some number of spots. If not specified different, we default
@@ -254,10 +253,10 @@ class FixtureMixin(object):
             if ('time_register_start' not in obj and
                     'time_register_end' not in obj):
                 obj['time_register_start'] = (
-                    datetime.now(pytz.utc) - timedelta(
+                    datetime.utcnow() - timedelta(
                         seconds=random.randint(0, 1000000)))
                 obj['time_register_end'] = (
-                    datetime.now(pytz.utc) + timedelta(
+                    datetime.utcnow() + timedelta(
                         seconds=random.randint(0, 1000000)))
             else:
                 if ('time_register_start' not in obj or
@@ -350,8 +349,8 @@ class FixtureMixin(object):
                 random.randint(0, date.max.toordinal()))
 
         elif t == 'datetime':
-            return datetime.fromtimestamp(
-                random.randint(0, 2**32)).replace(tzinfo=pytz.utc)
+            return datetime.utcfromtimestamp(
+                random.randint(0, 2**32))
 
         elif t == 'float':
             return random.rand() * random.randint(0, 2**32)

--- a/amivapi/tests/utils.py
+++ b/amivapi/tests/utils.py
@@ -113,12 +113,7 @@ class WebTest(unittest.TestCase, FixtureMixin):
         'SENTRY_ENVIRONMENT': None,
         'PASSWORD_CONTEXT': CryptContext(
             schemes=["pbkdf2_sha256"],
-
-            # default_rounds is used when hashing new passwords, to be varied
-            # each time by vary_rounds
             pbkdf2_sha256__default_rounds=10,
-            pbkdf2_sha256__vary_rounds=0.1,
-
             # min_rounds is used to determine if a hash needs to be upgraded
             pbkdf2_sha256__min_rounds=8,
         )
@@ -178,9 +173,9 @@ class WebTest(unittest.TestCase, FixtureMixin):
             created = datetime.now(timezone.utc)
 
         token = "test_token_" + str(next(self.counter))
-        self.db['sessions'].insert({u'user': ObjectId(user_id),
-                                    u'token': token,
-                                    u'_created': created})
+        self.db['sessions'].insert_one({u'user': ObjectId(user_id),
+                                        u'token': token,
+                                        u'_created': created})
         return token
 
     def get_root_token(self):

--- a/amivapi/users/security.py
+++ b/amivapi/users/security.py
@@ -194,7 +194,7 @@ def _hash_password(user):
     password_context = current_app.config['PASSWORD_CONTEXT']
 
     if user.get('password', None) is not None:
-        user['password'] = password_context.encrypt(user['password'])
+        user['password'] = password_context.hash(user['password'])
 
 
 def hash_on_insert(items):

--- a/amivapi/validation.py
+++ b/amivapi/validation.py
@@ -14,7 +14,7 @@ validate the schema itself.
 
 from datetime import datetime, timedelta, timezone
 from imghdr import what
-from collections import Hashable
+from collections.abc import Hashable
 from PIL import Image
 from bs4 import BeautifulSoup
 
@@ -51,7 +51,8 @@ class ValidatorAMIV(Validator):
         PATCH."""
         return ('dependencies',)
 
-    def validate_update(self, document, document_id, persisted_document=None):
+    def validate_update(self, document, document_id,
+                        persisted_document=None, normalize_document=True):
         """We change that some validators are run on all fields during PATCH.
 
         We need this to check that dependencies are not lost. If A depends on
@@ -63,7 +64,8 @@ class ValidatorAMIV(Validator):
         # called. This is not optimal, but ok, as we are not using a custom
         # error handler. There isn't really a better place to hook in our
         # dependency validators...
-        super().validate_update(document, document_id, persisted_document)
+        super().validate_update(document, document_id,
+                                persisted_document, normalize_document)
 
         for field in self._get_present_fields():
             definition = self.schema.get(field, {})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 eve==0.9.1
--e git+https://github.com/hermannsblum/eve-swagger.git@5c9cf066ffa72712f9018a3eb0c5142f7733d8cc#egg=Eve_Swagger
--e git+https://github.com/NotSpecial/nethz.git@1d3004081c3618f1f41463476a847b0bddd6d91a#egg=nethz
+git+https://github.com/hermannsblum/eve-swagger.git@5c9cf066ffa72712f9018a3eb0c5142f7733d8cc#egg=Eve_Swagger
+git+https://github.com/NotSpecial/nethz.git@1d3004081c3618f1f41463476a847b0bddd6d91a#egg=nethz
 passlib==1.7.1
 jsonschema==3.0.1
 freezegun==0.3.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,9 @@
-# Eve 0.8.2 fixes an important bug, enabling CORS for the /media endpoint,
-# which we require. As it is not released, we currently use the github branch.
-# As soon as 0.8.2. is released, we can switch back.
-#eve==0.8.2
--e git+https://github.com/pyeve/eve.git@48d9c25cdca04c2f5a31ce01a1310d493fc67eda#egg=Eve
+eve==0.9.1
 -e git+https://github.com/hermannsblum/eve-swagger.git@5c9cf066ffa72712f9018a3eb0c5142f7733d8cc#egg=Eve_Swagger
 -e git+https://github.com/NotSpecial/nethz.git@1d3004081c3618f1f41463476a847b0bddd6d91a#egg=nethz
-passlib==1.6.5
-jsonschema==2.5.1
-click==6.6
-pytz==2016.7
-freezegun==0.3.8
-sentry-sdk[flask]==0.4.1
-bs4==0.0.1
-Pillow==5.3.0
+passlib==1.7.1
+jsonschema==3.0.1
+freezegun==0.3.12
+sentry-sdk[flask]==0.8.1
+beautifulsoup4==4.6.3
+Pillow==6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 eve==0.9.1
 git+https://github.com/hermannsblum/eve-swagger.git@5c9cf066ffa72712f9018a3eb0c5142f7733d8cc#egg=Eve_Swagger
-git+https://github.com/NotSpecial/nethz.git@1d3004081c3618f1f41463476a847b0bddd6d91a#egg=nethz
+# "nethz" must be instaleld in editable mode, otherwise some certs are not found
+# Wontfix: With the upcoming migration, this library will not be needed anymore
+-e git+https://github.com/NotSpecial/nethz.git@1d3004081c3618f1f41463476a847b0bddd6d91a#egg=nethz
 passlib==1.7.1
 jsonschema==3.0.1
 freezegun==0.3.12


### PR DESCRIPTION
For some reason, the generic alpine image would not correctly update
the repositories and would not find mongodb.

With a fixed version, this issue does not occur anymore.

Additionally, important changes due to version update:

- Pytz: Dependency removed, as datetime
  can handle utc on its own.

- Cerberus: `valueschema` renamed to `valuesrules`.

- MongoDB: `insert` is replaced by `insert_one` and `insert_many`.
  As a consequence, ObjectIDs are retrieved
  a bit differently.

- PassLib: `encrypt` renamed to `hash`.
  `vary_round` is deprecated, has it
  "provided little security and was not worth
  the additional complexity" [1].

[1]: https://passlib.readthedocs.io/en/stable/history/1.7.html?highlight=vary_rounds#crypt-context-api-deprecations

Closes #394 (new eve version fixes this bug)