### PR TITLE
Add ratings for study documents.

### DIFF
--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -512,7 +512,8 @@ eventdomain = {
 
                 'data_relation': {
                     'resource': 'events',
-                    'embeddable': True
+                    'embeddable': True,
+                    'cascade_delete': True,
                 },
                 'not_patchable': True,
                 'required': True,

--- a/amivapi/studydocs/__init__.py
+++ b/amivapi/studydocs/__init__.py
@@ -8,12 +8,10 @@
 Contains settings for eve resource, special validation and email_confirmation
 logic needed for signup of non members to events.
 """
-from amivapi.studydocs.authorization import (
-    add_uploader_on_bulk_insert,
-    add_uploader_on_insert
-)
+from amivapi.studydocs.authorization import add_uploader_on_insert
 from amivapi.studydocs.summary import add_summary
-from amivapi.studydocs.rating import add_rating, add_rating_collection
+from amivapi.studydocs.rating import (
+    init_rating, update_rating_post, update_rating_patch, update_rating_delete)
 from amivapi.studydocs.model import studydocdomain, StudyDocValidator
 from amivapi.utils import register_domain, register_validator
 
@@ -24,12 +22,13 @@ def init_app(app):
     register_validator(app, StudyDocValidator)
 
     # Uploader
-    app.on_insert_item_studydocuments += add_uploader_on_insert
-    app.on_insert_studydocuments += add_uploader_on_bulk_insert
+    app.on_insert_studydocuments += add_uploader_on_insert
 
     # Rating
-    app.on_fetched_item_studydocuments += add_rating
-    app.on_fetched_resource_studydocuments += add_rating_collection
+    app.on_insert_studydocuments += init_rating
+    app.on_inserted_studydocumentratings += update_rating_post
+    app.on_updated_studydocumentratings += update_rating_patch
+    app.on_deleted_item_studydocumentratings += update_rating_delete
 
     # Meta summary
     app.on_fetched_resource_studydocuments += add_summary

--- a/amivapi/studydocs/__init__.py
+++ b/amivapi/studydocs/__init__.py
@@ -13,6 +13,7 @@ from amivapi.studydocs.authorization import (
     add_uploader_on_insert
 )
 from amivapi.studydocs.summary import add_summary
+from amivapi.studydocs.rating import add_rating, add_rating_collection
 from amivapi.studydocs.model import studydocdomain, StudyDocValidator
 from amivapi.utils import register_domain, register_validator
 
@@ -22,7 +23,13 @@ def init_app(app):
     register_domain(app, studydocdomain)
     register_validator(app, StudyDocValidator)
 
+    # Uploader
     app.on_insert_item_studydocuments += add_uploader_on_insert
     app.on_insert_studydocuments += add_uploader_on_bulk_insert
 
+    # Rating
+    app.on_fetched_item_studydocuments += add_rating
+    app.on_fetched_resource_studydocuments += add_rating_collection
+
+    # Meta summary
     app.on_fetched_resource_studydocuments += add_summary

--- a/amivapi/studydocs/authorization.py
+++ b/amivapi/studydocs/authorization.py
@@ -20,12 +20,7 @@ class StudydocsAuth(AmivTokenAuth):
         return True
 
 
-def add_uploader_on_insert(item):
-    """Add the _author field before inserting studydocs"""
-    item['uploader'] = g.get('current_user')
-
-
-def add_uploader_on_bulk_insert(items):
+def add_uploader_on_insert(items):
     """Add the _author field before inserting studydocs"""
     for item in items:
-        add_uploader_on_insert(item)
+        item['uploader'] = g.get('current_user')

--- a/amivapi/studydocs/authorization.py
+++ b/amivapi/studydocs/authorization.py
@@ -20,6 +20,21 @@ class StudydocsAuth(AmivTokenAuth):
         return True
 
 
+class StudydocratingsAuth(AmivTokenAuth):
+    def has_item_write_permission(self, user_id, item):
+        """Allow users to modify only their own ratings."""
+        # item['user'] is Objectid, convert to str
+        return user_id == str(get_id(item['user']))
+
+    def create_user_lookup_filter(self, user_id):
+        """Allow users to only see their own ratings."""
+        return {'user': user_id}
+
+    def has_resource_write_permission(self, user_id):
+        # All users can rate studydocs
+        return True
+
+
 def add_uploader_on_insert(items):
     """Add the _author field before inserting studydocs"""
     for item in items:

--- a/amivapi/studydocs/model.py
+++ b/amivapi/studydocs/model.py
@@ -36,6 +36,12 @@ file uploaders have additional permissions:
 
 <br />
 
+## Ratings
+
+TODO!
+
+<br />
+
 ## Summary
 
 For more efficient searching of study documents, a *summary* of available
@@ -196,7 +202,73 @@ studydocdomain = {
                 'description': 'The year in which the course *was taken*, '
                                'to separate older from newer files.',
                 'allow_summary': True,
-            }
+            },
+
+            'rating': {
+                'title': 'Study Document Rating',
+                'description': 'The study document rating as a fraction of '
+                               'upvotes divided by all votes. Computed using '
+                               'a confidence interval. Null if no votes have '
+                               'been cast.',
+                'example': '0.9',
+
+                'type': 'float',
+                'readonly': True,
+            },
+        },
+    },
+
+    'studydocratings': {
+        'resource_title': "Study Document Rating",
+        'item_title': "Study Document Rating",
+
+        'description': "Rating for Study documents (TODO)",
+
+        'resource_methods': ['GET', 'POST'],
+        'item_methods': ['GET', 'PATCH', 'DELETE'],
+
+         # TODO
+        'authentication': StudydocsAuth,
+
+        'schema': {
+            'user': {
+                'description': 'The rating user.',
+                'example': '679ff66720812cdc2da4fb4a',
+
+                'type': 'objectid',
+                'data_relation': {
+                    'resource': 'users',
+                    'embeddable': True,
+                    'cascade_delete': True,
+                },
+                'not_patchable': True,
+                'required': True,
+                'unique_combination': ['studydoc'],
+            },
+
+            'studydoc': {
+                'title': 'Study Document',
+                'description': 'The rated study doc.',
+                'example': '10d8e50e303049ecb856ae9b',
+
+                'data_relation': {
+                    'resource': 'studydocuments',
+                    'embeddable': True,
+                    'cascade_delete': True,
+                },
+                'not_patchable': True,
+                'required': True,
+                'type': 'objectid',
+            },
+            'rating': {
+                'description': 'The given rating, can be an up- or downvote.',
+                'example': 'up',
+
+                'type': 'string',
+                'allowed': ['up', 'down'],
+                'required': True
+            },
         },
     }
+
 }

--- a/amivapi/studydocs/model.py
+++ b/amivapi/studydocs/model.py
@@ -218,8 +218,8 @@ studydocdomain = {
         },
     },
 
-    'studydocratings': {
-        'resource_title': "Study Document Rating",
+    'studydocumentratings': {
+        'resource_title': "Study Document Ratings",
         'item_title': "Study Document Rating",
 
         'description': "Rating for Study documents (TODO)",
@@ -227,7 +227,7 @@ studydocdomain = {
         'resource_methods': ['GET', 'POST'],
         'item_methods': ['GET', 'PATCH', 'DELETE'],
 
-         # TODO
+        # TODO
         'authentication': StudydocsAuth,
 
         'schema': {
@@ -243,10 +243,10 @@ studydocdomain = {
                 },
                 'not_patchable': True,
                 'required': True,
-                'unique_combination': ['studydoc'],
+                'unique_combination': ['studydocument'],
             },
 
-            'studydoc': {
+            'studydocument': {
                 'title': 'Study Document',
                 'description': 'The rated study doc.',
                 'example': '10d8e50e303049ecb856ae9b',

--- a/amivapi/studydocs/rating.py
+++ b/amivapi/studydocs/rating.py
@@ -18,8 +18,10 @@ from math import sqrt
 from amivapi.utils import get_id
 
 
-def lower_confidence_bound(upvotes, downvotes, z=1.28):
-    """Compute the lower bound of the wilson confidence interval is returned,
+def compute_rating(upvotes, downvotes, z=1.28):
+    """Compute the rating.
+
+    Concretely, the lower bound of the wilson confidence interval is returned,
     which takes the number of votes into account. [1]
 
     We use z = 1.28 by default, which corresponds to a 80% confidence interval
@@ -51,7 +53,7 @@ def _update_rating(studydoc_id):
     downvotes = ratings.count_documents({'rating': 'down', **lookup})
 
     # Compute rating and write to database
-    rating = lower_confidence_bound(upvotes, downvotes)
+    rating = compute_rating(upvotes, downvotes)
     docs.update_one({'_id': studydoc_id}, {'$set': {'rating': rating}})
 
 
@@ -59,9 +61,6 @@ def init_rating(items):
     """On creating of a study-document, set the rating to None."""
     for item in items:
         item['rating'] = None
-    # lookup = {'_id': {'$in': [get_id(item['_id']) for item in items]}}
-    # updates = {'$set': {'rating': None}}
-    # current_app.data.driver.db['studydocuments'].update_many(lookup, updates)
 
 
 def update_rating_post(items):

--- a/amivapi/studydocs/rating.py
+++ b/amivapi/studydocs/rating.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# license: AGPLv3, see LICENSE for details. In addition we strongly encourage
+#          you to buy us beer if we meet and you like the software.
+"""Studydoc rating computation."""
+
+from bson import ObjectId
+from flask import current_app
+from math import sqrt
+
+
+def lower_confidence_bound(upvotes, downvotes, z=1.28):
+    """Compute the lower bound of the wilson confidence interval is returned,
+    which takes the number of votes into account. [1]
+
+    We use z = 1.28 by default, which corresponds to a 80% confidence interval
+    (As there are only a few votes, we do not want to be overly cautious).
+
+    [1]: http://www.evanmiller.org/how-not-to-sort-by-average-rating.html
+    """
+    total = upvotes + downvotes
+    if not total:
+        return
+
+    p = upvotes / total
+    bound = ((p + (z**2)/(2*total) -
+              z * sqrt((p * (1-p) + (z**2)/(4*total)) / total)) /
+             (1 + (z**2)/total))
+
+    # Ensure that the bound is not below 0
+    return max(bound, 0)
+
+
+def add_rating(item):
+    """Computes the rating for a study document."""
+    ratings = current_app.data.driver.db['studydocratings']
+    lookup = {'studydoc': ObjectId(item['_id'])}
+
+    upvotes = ratings.count_documents({'rating': 'up', **lookup})
+    downvotes = ratings.count_documents({'rating': 'down', **lookup})
+
+    item['rating'] = lower_confidence_bound(upvotes, downvotes)
+
+
+def add_rating_collection(response):
+    for item in response['_items']:
+        add_rating(item)

--- a/amivapi/tests/studydocs/test_rating.py
+++ b/amivapi/tests/studydocs/test_rating.py
@@ -12,7 +12,7 @@ class StudydocsRatingTest(WebTestNoAuth):
     """Test rating computation."""
 
     def test_no_rating(self):
-        """Without any votes, the rating is None."""
+        """Without any votes, the `rating` is in the document, and is None."""
         doc = self.new_object('studydocuments')
 
         response = self.api.get('/studydocuments/' + str(doc['_id']),
@@ -30,6 +30,9 @@ class StudydocsRatingTest(WebTestNoAuth):
             (5, 2, 0.47),
             (5, 5, 0.31),
             (50, 50, 0.44),
+            (0, 1, 0.0),
+            (0, 5, 0.0),
+            (0, 10, 0.0),
         ]:
             bound = lower_confidence_bound(upvotes, downvotes)
             self.assertAlmostEqual(rating, bound, 2)
@@ -37,7 +40,7 @@ class StudydocsRatingTest(WebTestNoAuth):
     def test_rating(self):
         """Test that the rating is correctly attached to the studydoc."""
         doc = self.new_object('studydocuments')
-        lookup = {'studydoc': str(doc['_id'])}
+        lookup = {'studydocument': str(doc['_id'])}
 
         response = self.api.get('/studydocuments/' + str(doc['_id']),
                                 status_code=200)
@@ -46,9 +49,84 @@ class StudydocsRatingTest(WebTestNoAuth):
 
         self.load_fixture({
             'users': [{}],
-            'studydocratings': [{'rating': 'up', **lookup}],
+            'studydocumentratings': [{'rating': 'up', **lookup}],
         })
 
         response = self.api.get('/studydocuments/' + str(doc['_id']),
                                 status_code=200)
         self.assertAlmostEqual(response.json['rating'], 0.38, 2)
+
+    def test_sort_by_rating(self):
+        """Ensure that sorting by rating works."""
+        ids = [24 * '0', 24 * '1', 24 * '2']
+        self.load_fixture({
+            'users': [{}],
+            'studydocuments': [
+                {'_id': ids[0]}, {'_id': ids[1]}, {'_id': ids[2]}
+            ],
+            'studydocumentratings': [
+                # Rate such that:
+                # 0: No rating, 1: Low rating, 2: High rating
+                {'studydocument': ids[2], 'rating': 'up'},
+                {'studydocument': ids[1], 'rating': 'down'},
+            ],
+        })
+        response = self.api.get('/studydocuments?sort=rating', status_code=200)
+        for (item, expected_id) in zip(response.json['_items'], ids):
+            self.assertEqual(item['_id'], expected_id)
+
+        # Also test reverse order, to ensure that it was no accident
+        response = self.api.get('/studydocuments?sort=-rating', status_code=200)
+        for (item, expected_id) in zip(response.json['_items'], ids[::-1]):
+            self.assertEqual(item['_id'], expected_id)
+
+    def _assert_rating(self, studydoc_id, rating):
+        response = self.api.get('/studydocuments/' + studydoc_id,
+                                status_code=200)
+        self.assertAlmostEqual(response.json['rating'], rating, 2)
+
+    def test_new_vote(self):
+        """POSTing a new vote updates the rating."""
+        user = str(self.new_object('users')['_id'])
+        doc = str(self.new_object('studydocuments')['_id'])
+        self._assert_rating(doc, None)
+
+        data = {'user': user, 'studydocument': doc, 'rating': 'up'}
+        self.api.post('/studydocumentratings', data=data, status_code=201)
+        self._assert_rating(doc, 0.38)
+
+    def test_change_vote(self):
+        """PATCHing an existing vote updates the rating."""
+        self.new_object('users')
+        doc = str(self.new_object('studydocuments')['_id'])
+        rating = self.new_object('studydocumentratings', rating='up')
+        self._assert_rating(doc, 0.38)
+
+        headers = {'If-Match': rating['_etag']}
+        data = {'rating': 'down'}
+        self.api.patch('/studydocumentratings/' + str(rating['_id']),
+                       data=data, headers=headers, status_code=200)
+        self._assert_rating(doc, 0.0)
+
+    def test_delete_vote(self):
+        """DELETEing votes update the rating."""
+        user_1, user_2 = self.load_fixture({'users': [{}, {}]})
+        doc = str(self.new_object('studydocuments')['_id'])
+        rating_1, rating_2 = self.load_fixture({
+            'studydocumentratings': [
+                {'user': str(user_1['_id']), 'rating': 'up'},
+                {'user': str(user_2['_id']), 'rating': 'down'}
+            ]
+        })
+        self._assert_rating(doc, 0.16)
+
+        self.api.delete('/studydocumentratings/' + str(rating_2['_id']),
+                        headers={'If-Match': rating_2['_etag']},
+                        status_code=204)
+        self._assert_rating(doc, 0.38)
+
+        # After the last rating get's deleted, the rating is `None` again
+        self.api.delete('/studydocumentratings/' + str(rating_1['_id']),
+                        headers={'If-Match': rating_1['_etag']},
+                        status_code=204)
+        self._assert_rating(doc, None)

--- a/amivapi/tests/studydocs/test_rating.py
+++ b/amivapi/tests/studydocs/test_rating.py
@@ -4,7 +4,7 @@
 #          you to buy us beer if we meet and you like the software.
 """Tests for studydocuments rating."""
 
-from amivapi.studydocs.rating import lower_confidence_bound
+from amivapi.studydocs.rating import compute_rating
 from amivapi.tests.utils import WebTest, WebTestNoAuth
 
 
@@ -34,7 +34,7 @@ class StudydocsRatingTest(WebTestNoAuth):
             (0, 5, 0.0),
             (0, 10, 0.0),
         ]:
-            bound = lower_confidence_bound(upvotes, downvotes)
+            bound = compute_rating(upvotes, downvotes)
             self.assertAlmostEqual(rating, bound, 2)
 
     def test_rating(self):

--- a/amivapi/tests/studydocs/test_rating.py
+++ b/amivapi/tests/studydocs/test_rating.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# license: AGPLv3, see LICENSE for details. In addition we strongly encourage
+#          you to buy us beer if we meet and you like the software.
+"""Tests for studydocuments rating."""
+
+from amivapi.studydocs.rating import lower_confidence_bound
+from amivapi.tests.utils import WebTestNoAuth
+
+
+class StudydocsRatingTest(WebTestNoAuth):
+    """Test rating computation."""
+
+    def test_no_rating(self):
+        """Without any votes, the rating is None."""
+        doc = self.new_object('studydocuments')
+
+        response = self.api.get('/studydocuments/' + str(doc['_id']),
+                                status_code=200)
+
+        self.assertIsNone(response.json['rating'])
+
+    def test_bound(self):
+        """Without any votes, the rating is None."""
+        for upvotes, downvotes, rating in [
+            (1, 0, 0.38),
+            (5, 0, 0.75),
+            (10, 0, 0.86),
+            (1, 1, 0.16),
+            (5, 2, 0.47),
+            (5, 5, 0.31),
+            (50, 50, 0.44),
+        ]:
+            bound = lower_confidence_bound(upvotes, downvotes)
+            self.assertAlmostEqual(rating, bound, 2)
+
+    def test_rating(self):
+        """Test that the rating is correctly attached to the studydoc."""
+        doc = self.new_object('studydocuments')
+        lookup = {'studydoc': str(doc['_id'])}
+
+        response = self.api.get('/studydocuments/' + str(doc['_id']),
+                                status_code=200)
+        # No ratings yet
+        self.assertIsNone(response.json['rating'])
+
+        self.load_fixture({
+            'users': [{}],
+            'studydocratings': [{'rating': 'up', **lookup}],
+        })
+
+        response = self.api.get('/studydocuments/' + str(doc['_id']),
+                                status_code=200)
+        self.assertAlmostEqual(response.json['rating'], 0.38, 2)

--- a/amivapi/tests/studydocs/test_studydocs_auth.py
+++ b/amivapi/tests/studydocs/test_studydocs_auth.py
@@ -88,3 +88,16 @@ class StudydocsAuthTest(WebTest):
 
         docs = self.api.get('/studydocuments', token=token, status_code=200)
         self.assertEqual(len(docs.json['_items']), 5)
+
+
+class StudyDocRatingAuthTest(WebTest):
+    """Test for rating authentication."""
+
+    def test_own_ratings(self):
+        ...
+
+    def test_other_ratings(self):
+        ...
+
+    def test_admin_ratings(self):
+        ...


### PR DESCRIPTION
Add a rating for study documents, via a new endpoint `studydocumentratings` to rate, and a field `rating` to display the result.

We do not simply return the average vote, which can be quite far off, since we don't have many votes in general.

Instead, we return the lower bound of a statistical confidence interval.

On the one hand, it is useful, but actually I thought it's a neat approach, and since it is not much more complicated than an average rating I went for it^^
(The actual formula is a bit more complex, but thats it)

[More info :)](http://www.evanmiller.org/how-not-to-sort-by-average-rating.html)

Closes #89