### PR TITLE
Fix ldap membership detection (students >2019).

### DIFF
--- a/amivapi/ldap.py
+++ b/amivapi/ldap.py
@@ -32,6 +32,12 @@ always the same, and the second part of the string contains further details.
 We therefore match the first part of the `departmentNumber` field to
 check for the department. In the app settings, we define which substring
 is mapped to which department.
+
+As of fall 2019, this information seems to have move to the `description` field,
+and looks (almost) identical, except that the string does not start with "ETH "
+anymore. Unfortunately, the info for all previous students is still in the
+`departmentNumber` field, thus we check which of both fields is in use before
+parsing.
 """
 
 from eve.methods.patch import patch_internal
@@ -115,8 +121,10 @@ def _search(query):
         'givenName',
         'sn',
         'swissEduPersonGender',
+        'ou',
+        # Dept for old students in 'departmentNumber', for new in 'description'
         'departmentNumber',
-        'ou'
+        'description',
     ]
     results = current_app.config['ldap_connector'].search(query,
                                                           attributes=attr)
@@ -157,10 +165,12 @@ def _process_data(data):
     # See file docstring for explanation of `deparmentNumber` field
     # In some rare cases, the departmentNumber field is either empty
     # or missing -> normalize to empty string
-    department_number = next(iter(data.get('departmentNumber', [])), '')
+    department_info = next(iter(
+        data.get('departmentNumber') or data.get('description') or []
+    ), '')
     department_map = current_app.config['LDAP_DEPARTMENT_MAP'].items()
     department = (dept for phrase, dept in department_map
-                  if phrase in department_number)
+                  if phrase in department_info)
     res['department'] = next(department, None)  # None if no match
 
     # Membership: One of our departments and VSETH member

--- a/amivapi/settings.py
+++ b/amivapi/settings.py
@@ -158,10 +158,10 @@ SIGNUP_DELETED_TEXT = "Your signup was removed."
 # We can use this to discover department of students
 LDAP_DEPARTMENT_MAP = {
     # (phrase in departmentNumber for our members): department of member
-    u'ETH Student D-ITET': u'itet',  # for BSc, MSc as well as PhD students!
-    u'ETH Studentin D-ITET': u'itet',
-    u'ETH Student D-MAVT': u'mavt',
-    u'ETH Studentin D-MAVT': u'mavt',
+    u'Student D-ITET': u'itet',  # for BSc, MSc as well as PhD students!
+    u'Studentin D-ITET': u'itet',
+    u'Student D-MAVT': u'mavt',
+    u'Studentin D-MAVT': u'mavt',
     # All other departments are mapped to 'None' (s.t. None equals 'no member')
 }
 

--- a/amivapi/tests/test_ldap.py
+++ b/amivapi/tests/test_ldap.py
@@ -223,8 +223,9 @@ class LdapTest(WebTestNoAuth):
             'givenName',
             'sn',
             'swissEduPersonGender',
+            'ou',
             'departmentNumber',
-            'ou'
+            'description',
         ]
         mock_results = [1, 2, 3]
         # Mock ldap query
@@ -349,6 +350,7 @@ class LdapIntegrationTest(WebTest):
             user = ldap.sync_one(LDAP_USER_NETHZ)
             data_only = {key: value for (key, value) in user.items()
                          if not key.startswith('_')}  # no meta fields
+            data_only.pop('password_set')  # meta field as well
 
             # Double check with database
             db_user = self.db['users'].find_one({'nethz': LDAP_USER_NETHZ})


### PR DESCRIPTION
As of fall 2019, the LDAP data for students has changed.
The general string from which we detect membership has moved from the `departmentNumber` field to the (new) `description` field.
Unfortunately, the info for all previous students is still in the
`departmentNumber` field, thus we now check which of both fields is in use before
parsing.