### PR TITLE
LDAP: prefer description over departmentNumber.

### DIFF
--- a/amivapi/ldap.py
+++ b/amivapi/ldap.py
@@ -166,7 +166,7 @@ def _process_data(data):
     # In some rare cases, the departmentNumber field is either empty
     # or missing -> normalize to empty string
     department_info = next(iter(
-        data.get('departmentNumber') or data.get('description') or []
+        data.get('description') or data.get('departmentNumber') or []
     ), '')
     department_map = current_app.config['LDAP_DEPARTMENT_MAP'].items()
     department = (dept for phrase, dept in department_map


### PR DESCRIPTION
In #398, we introduced parsing a (new) LDAP field `description`, which substitutes the old
`departmentNumber` field for new students.

We have however noticed that the `departmentNumber` field still exists for (only a few) of the
new students, however with uninformative input such as "Student".

To ensure smooth operation, we should thus check the description field first, as it is the
new official field with the information we need, and only fall back to the departmentnumber field
if it is missing.