### PR TITLE
Fix FCFS POST issue for admins (fix #381)

### DIFF
--- a/amivapi/events/queue.py
+++ b/amivapi/events/queue.py
@@ -4,7 +4,7 @@
 #          you to buy us beer if we meet and you like the software.
 """Logic to implement different signup queues."""
 
-from flask import current_app
+from flask import current_app, g
 from pymongo import ASCENDING
 
 from amivapi.events.emails import notify_signup_accepted
@@ -65,7 +65,7 @@ Hooks that trigger fcfs execution
 def add_accepted_before_insert(signups):
     """Add the accepted field before inserting signups."""
     for signup in signups:
-        signup['accepted'] = False
+        signup['accepted'] = g.resource_admin and signup.get('accepted', False)
 
 
 def update_waiting_list_after_insert(signups):

--- a/amivapi/events/queue.py
+++ b/amivapi/events/queue.py
@@ -65,6 +65,8 @@ Hooks that trigger fcfs execution
 def add_accepted_before_insert(signups):
     """Add the accepted field before inserting signups."""
     for signup in signups:
+        # Admins may provide a value for `accepted`.
+        # If not provided or not admin set it to false`.
         signup['accepted'] = g.resource_admin and signup.get('accepted', False)
 
 

--- a/amivapi/tests/events/test_queue.py
+++ b/amivapi/tests/events/test_queue.py
@@ -55,6 +55,15 @@ class EventsignupQueueTest(WebTestNoAuth):
                                     status_code=200).json
         self.assertTrue(user2_signup['accepted'])
 
+        # post accepted signup as admin
+        user1_signup = self.api.post('/eventsignups', data={
+            'user': str(user1['_id']),
+            'event': str(event['_id']),
+            'accepted': True
+        }, status_code=201).json
+
+        self.assertTrue(user1_signup['accepted'])
+
     def test_fcfs_users_get_auto_accepted_unlimited_spots(self):
         """Test that with fcfs the users get automatically accepted on signup
         for events with unlimited spaces"""


### PR DESCRIPTION
Fixes the accepted signup POST issue when the action is performed by an admin.