### PR TITLE
Fix newsletter subscription with LDAP user import (Fix #400)

### DIFF
--- a/amivapi/ldap.py
+++ b/amivapi/ldap.py
@@ -195,9 +195,9 @@ def _create_or_update_user(ldap_data):
             # Membership will not be downgraded and email not be overwritten
             # Newletter settings will also not be adjusted
             ldap_data.pop('email', None)
-            ldap_data.pop('send_newsletter', None)
             if db_data.get('membership') != u"none":
                 ldap_data.pop('membership', None)
+                ldap_data.pop('send_newsletter', None)
 
             user = patch_internal('users',
                                   ldap_data,

--- a/amivapi/tests/test_ldap.py
+++ b/amivapi/tests/test_ldap.py
@@ -214,6 +214,26 @@ class LdapTest(WebTestNoAuth):
             else:
                 self.assertEqual(result[field], db_value)
 
+    def test_upgrade_membership(self):
+        # Insert non-member and upgrade by ldap later
+        user = self.api.post('/users', data={
+            'nethz': 'pablo',
+            'email': 'pablo@ethz.ch',  # this will be auto-generated
+            'firstname': 'P',
+            'lastname': 'Ablo',
+            'department': 'itet',
+            'membership': 'none',
+            'gender': 'female',
+            'legi': '01234567',
+            'send_newsletter': False,
+        }, status_code=201).json
+        self.assertFalse(user['send_newsletter'])
+
+        with self.app.test_request_context():
+            result = ldap._create_or_update_user(self.fake_filtered_data())
+
+        self.assertTrue(result['send_newsletter'])
+
     def test_search(self):
         """Test that ldap is correctly queried."""
         test_query = "äüáíðáßðöó"


### PR DESCRIPTION
Ensures that the newsletter is subscribed when new members are imported/updated from LDAP.

Fixes #400 