### PR TITLE
Fix issue for sending event signup confirm email

### DIFF
--- a/amivapi/events/emails.py
+++ b/amivapi/events/emails.py
@@ -52,7 +52,7 @@ def send_confirmmail_to_unregistered_users(items):
         item: The item, which was just inserted into the database
     """
     for item in items:
-        if 'user' not in item or item['user'] is None:
+        if item.get('user') is None:
             event = current_app.data.find_one(
                 'events', None,
                 **{current_app.config['ID_FIELD']: item['event']})

--- a/amivapi/events/emails.py
+++ b/amivapi/events/emails.py
@@ -52,7 +52,7 @@ def send_confirmmail_to_unregistered_users(items):
         item: The item, which was just inserted into the database
     """
     for item in items:
-        if 'user' not in item:
+        if 'user' not in item or item['user'] is None:
             event = current_app.data.find_one(
                 'events', None,
                 **{current_app.config['ID_FIELD']: item['event']})

--- a/amivapi/tests/events/test_emails.py
+++ b/amivapi/tests/events/test_emails.py
@@ -41,6 +41,36 @@ class EventMailTest(WebTestNoAuth):
                               status_code=200).json
         self.assertEqual(signup['confirmed'], True)
 
+    def test_email_token_when_user_null(self):
+        """Test confirmation by email link when user is set to None."""
+        event = self.new_object('events', spots=100, allow_email_signup=True)
+        signup = self.api.post('/eventsignups', data={
+            'event': str(event['_id']),
+            'user': None,
+            'email': 'bla@test.bla'
+        }, status_code=201).json
+
+        self.assertEqual(signup['confirmed'], False)
+        self.assertEqual(len(self.app.test_mails), 1)
+
+        # Look for sent out mail
+        mail = self.app.test_mails[0]
+        self.assertEqual(mail['receivers'][0], 'bla@test.bla')
+
+        # Use the confirm link
+        token = re.search(r'/confirm_email/(.+)\n\n', mail['text']).group(1)
+        # With redirect set
+        self.app.config['EMAIL_CONFIRMED_REDIRECT'] = "somewhere"
+        self.api.get('/confirm_email/%s' % token, status_code=302)
+        # And without
+        self.app.config.pop('EMAIL_CONFIRMED_REDIRECT')
+        self.api.get('/confirm_email/%s' % token, status_code=200)
+
+        # Check that the signup got confirmed
+        signup = self.api.get('/eventsignups/%s' % signup['_id'],
+                              status_code=200).json
+        self.assertEqual(signup['confirmed'], True)
+
     def test_email_signup_delete(self):
         """Test deletion of signup via email link."""
         event = self.new_object('events', spots=100, selection_strategy='fcfs')

--- a/amivapi/tests/events/test_emails.py
+++ b/amivapi/tests/events/test_emails.py
@@ -41,8 +41,8 @@ class EventMailTest(WebTestNoAuth):
                               status_code=200).json
         self.assertEqual(signup['confirmed'], True)
 
-    def test_email_token_when_user_null(self):
-        """Test confirmation by email link when user is set to None."""
+    def test_confirmation_email_when_user_null(self):
+        """Test confirmation email when user is explicitly set to None."""
         event = self.new_object('events', spots=100, allow_email_signup=True)
         signup = self.api.post('/eventsignups', data={
             'event': str(event['_id']),
@@ -56,20 +56,6 @@ class EventMailTest(WebTestNoAuth):
         # Look for sent out mail
         mail = self.app.test_mails[0]
         self.assertEqual(mail['receivers'][0], 'bla@test.bla')
-
-        # Use the confirm link
-        token = re.search(r'/confirm_email/(.+)\n\n', mail['text']).group(1)
-        # With redirect set
-        self.app.config['EMAIL_CONFIRMED_REDIRECT'] = "somewhere"
-        self.api.get('/confirm_email/%s' % token, status_code=302)
-        # And without
-        self.app.config.pop('EMAIL_CONFIRMED_REDIRECT')
-        self.api.get('/confirm_email/%s' % token, status_code=200)
-
-        # Check that the signup got confirmed
-        signup = self.api.get('/eventsignups/%s' % signup['_id'],
-                              status_code=200).json
-        self.assertEqual(signup['confirmed'], True)
 
     def test_email_signup_delete(self):
         """Test deletion of signup via email link."""


### PR DESCRIPTION
Ensures that a confirm email is sent to an event signup by email even
when "user" is set to null in the request payload.

**Previous behavior**

No confirm email was sent to the given email address, when `user` is in the request payload although its value is set to the default value `null`.
```
{
  "event": "<event-id>",
  "user": null,
  "email": "test@bla.ts"
}
```

With this PR, a confirmation email is also sent in this case.