### PR TITLE
Add `oral exams` and `study guides` to study document types.

### DIFF
--- a/amivapi/studydocs/model.py
+++ b/amivapi/studydocs/model.py
@@ -184,8 +184,9 @@ studydocdomain = {
                 'type': 'string',
                 'nullable': True,
                 'default': None,
-                'allowed': ['exams', 'cheat sheets', 'lecture documents',
-                            'exercises'],
+                'allowed': ['exams', 'oral exams',
+                            'cheat sheets', 'study guides',
+                            'lecture documents', 'exercises'],
                 'allow_summary': True,
             },
             'course_year': {


### PR DESCRIPTION
This PR adds two new types of study documents: `oral exams` and `study guides`.

- `oral exams` are introduces mainly for maintenance. We received complaints that it is hard to get an overview of available oral exams because it is currently impossible to differentiate them from normal exams.
- `study guides` are mainly intended for the AMIV PVK, but also for similar amiv-hosted courses that provide guides in form of scripts or presentations to students. They are different from `cheat sheets`, as they are much more extensive. And they are different from `lecture documents`, as they are neither official documents, nor necessarily follow the lecture structure (e.g. a PVK might cover the topics of a lecture, but present them in different order and context). Finally, there is a need for students to find study guides (compared to generic lecture notes) for their exam preparations.

@markusniese has agreed to oversee reclassifying existing documents (oral exams and study guides) to the new categories.

Closes #420.