### PR TITLE
Studydocs: Always require type and add options.

### DIFF
--- a/amivapi/studydocs/model.py
+++ b/amivapi/studydocs/model.py
@@ -182,9 +182,9 @@ studydocdomain = {
             'type': {
                 'example': 'cheat sheets',
                 'type': 'string',
-                'nullable': True,
-                'default': None,
-                'allowed': ['exams', 'oral exams',
+                'required': True,
+                'nullable': False,
+                'allowed': ['spring exams', 'autumn exams', 'oral exams',
                             'cheat sheets', 'study guides',
                             'lecture documents', 'exercises'],
                 'allow_summary': True,


### PR DESCRIPTION
We do not wish to allow studydocs without type anymore, so the `type` field is not not nullable and required.

Furthermore, we wish to differentiate between spring and autumn exams for better filtering, so the previous exam type is replaced.

Closes #422