### PR TITLE
Remove unnecessary package 'python-dev'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV AMIVAPI_CONFIG=/api/config.py
 
 # Install bjoern and dependencies for install
 RUN apk add --no-cache --virtual .deps \
-        musl-dev python-dev gcc git && \
+        musl-dev gcc git && \
     # Keep libev for running bjoern, libjpeg and zlib for Pillow
     apk add --no-cache libev-dev zlib-dev jpeg-dev && \
     pip install bjoern

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -5,7 +5,7 @@ RUN adduser -Dh /api amivapi
 WORKDIR /api
 
 # Install packages.
-RUN apk add --no-cache musl-dev python-dev gcc git bash && \
+RUN apk add --no-cache musl-dev gcc git bash && \
     #  libjpeg and zlib for Pillow
     apk add --no-cache zlib-dev jpeg-dev && \
     apk add --no-cache mongodb


### PR DESCRIPTION
The package `python-dev` was decomissioned with Python 2.
We do not need anything from this package so we should just remove it so that the docker build succeeds again.