### PR TITLE
Allow login if LDAP auth works, but sync fails.

### DIFF
--- a/amivapi/auth/sessions.py
+++ b/amivapi/auth/sessions.py
@@ -182,10 +182,10 @@ def process_login(items):
             # Success, sync user and get token
             try:
                 user = ldap.sync_one(username)
+                app.logger.info(
+                    "User '%s' was authenticated with LDAP" % username)
             except LDAPException:
                 # Sync failed! Try to find user in db.
-                app.logger.error(f"User '{username}' was authenticated, " +
-                                 "but could not be synced.")
                 user = _find_user(username)
                 if user:
                     app.logger.error(
@@ -199,8 +199,6 @@ def process_login(items):
                     abort(401, description=debug_error_message(status))
 
             _prepare_token(item, user['_id'])
-            app.logger.info(
-                "User '%s' was authenticated with LDAP" % username)
             return
 
         # Database, try to find via nethz, mail or objectid

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ eve==1.1.5
 git+https://github.com/hermannsblum/eve-swagger.git@5c9cf066ffa72712f9018a3eb0c5142f7733d8cc#egg=Eve_Swagger
 # "nethz" must be installed in editable mode, otherwise some certs are not found
 # Wontfix: With the upcoming migration, this library will not be needed anymore
--e git+https://github.com/NotSpecial/nethz.git@1d3004081c3618f1f41463476a847b0bddd6d91a#egg=nethz
+-e git+https://github.com/NotSpecial/nethz.git@fcd5ced2dd365f237047748abfedb9c35a468393#egg=nethz
 passlib==1.7.4
 jsonschema==3.2.0
 freezegun==1.1.0


### PR DESCRIPTION
The LDAP sync requires additional credentials.
If there are problems with these, sync can fail
(even if auth works).

To reduce the damage, this change allows in-db users to still log in,
even if sync failed.
(As long as they can be authenticated).