### PR TITLE
User cleanup

### DIFF
--- a/amivapi/tests/users/test_user_cleanup.py
+++ b/amivapi/tests/users/test_user_cleanup.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+#
+# license: AGPLv3, see LICENSE for details. In addition we strongly encourage
+#          you to buy us beer if we meet and you like the software.
+"""Tests for user module.
+
+Test if inactive non-members get deleted from database
+"""
+
+from datetime import datetime, timedelta
+from lib2to3.pgen2 import token
+from signal import SIG_DFL
+from freezegun import freeze_time
+
+from amivapi import cron
+from amivapi.tests import utils
+from amivapi.users import cleanup
+
+
+
+class UserCleanupTest(utils.WebTest):
+    """Test automatic User Cleanup"""
+
+    def test_autodelete(self):
+        entries = [
+            {
+                'nethz': 'pablamiv',
+                'firstname': "Pabla",
+                'lastname': "AMIV",
+                'email': "pabla@amiv.ch",
+                'gender': 'male',
+                'membership': 'none'
+            },
+            {
+                'nethz': 'pablomiv',
+                'firstname': "Pablo",
+                'lastname': "AMIV",
+                'email': "pablo@amiv.ch",
+                'gender': 'male',
+                'membership': "regular"
+            },
+            {
+                'nethz': 'pablemiv',
+                'firstname': "Pable",
+                'lastname': "AMIV",
+                'email': "pable@amiv.ch",
+                'gender': 'male',
+                'membership': "none"
+            },
+            {
+                'nethz': 'pablimiv',
+                'firstname': "Pabli",
+                'lastname': "AMIV",
+                'email': "pabli@amiv.ch",
+                'gender': 'male',
+                'membership': "honorary"
+            }
+        ]
+
+        root_token = self.get_root_token()
+        
+        with self.app.app_context():
+            with freeze_time("2019-08-24T14:15:22Z"):
+                # Non-member, updated 6 Month ago
+                self.api.post("/users", data=entries[0], token=root_token)
+                # Member, updated 6 Month ago
+                self.api.post("/users", data=entries[1], token=root_token)
+
+            with freeze_time("2018-08-24T14:15:22Z"):
+                # Non-member, updated 18 Month ago (should be deleted)
+                self.api.post("/users", data=entries[2], token=root_token)
+                # (honorary) Member, updated 18 Month ago
+                self.api.post("/users", data=entries[3], token=root_token)
+
+            users = self.api.get("/users", token=root_token ).json
+            self.assertEqual(len(users['_items']), 4)
+
+            with freeze_time("2019-12-24T14:15:22Z"):
+                cleanup.remove_inactive_users()
+
+            users = self.api.get("/users", token=root_token ).json
+
+        self.assertEqual(len(users['_items']), 3)

--- a/amivapi/tests/users/test_user_cleanup.py
+++ b/amivapi/tests/users/test_user_cleanup.py
@@ -17,60 +17,51 @@ class UserCleanupTest(utils.WebTest):
     """Test automatic User Cleanup"""
 
     def test_autodelete(self):
+        cleanup_time = "2019-12-24T14:15:22Z"
+
         entries = [
             {
-                'nethz': 'pablamiv',
-                'firstname': "Pabla",
-                'lastname': "AMIV",
-                'email': "pabla@amiv.ch",
-                'gender': 'male',
-                'membership': 'none'
+                # Non-member updated 6 months prior to cleanup.
+                'membership': 'none',
+                'updated': '2019-08-24T14:15:22Z'
             },
             {
-                'nethz': 'pablomiv',
-                'firstname': "Pablo",
-                'lastname': "AMIV",
-                'email': "pablo@amiv.ch",
-                'gender': 'male',
-                'membership': "regular"
+                # Regular member updated 6 months prior to cleanup.
+                'membership': 'regular',
+                'updated': '2019-08-24T14:15:22Z'
             },
             {
-                'nethz': 'pablemiv',
-                'firstname': "Pable",
-                'lastname': "AMIV",
-                'email': "pable@amiv.ch",
-                'gender': 'male',
-                'membership': "none"
+                # Non-member updated 18 months prior to cleanup.
+                # This use should be removed during cleanup.
+                'membership': 'none',
+                'updated': '2018-08-24T14:15:22Z'
             },
             {
-                'nethz': 'pablimiv',
-                'firstname': "Pabli",
-                'lastname': "AMIV",
-                'email': "pabli@amiv.ch",
-                'gender': 'male',
-                'membership': "honorary"
+                # Honorary member updated 18 months prior to cleanup.
+                'membership': 'honorary',
+                'updated': '2018-08-24T14:15:22Z'
             }
         ]
 
         root_token = self.get_root_token()
 
         with self.app.app_context():
-            with freeze_time("2019-08-24T14:15:22Z"):
-                # Non-member, updated 6 Month ago
-                self.api.post("/users", data=entries[0], token=root_token)
-                # Member, updated 6 Month ago
-                self.api.post("/users", data=entries[1], token=root_token)
-
-            with freeze_time("2018-08-24T14:15:22Z"):
-                # Non-member, updated 18 Month ago (should be deleted)
-                self.api.post("/users", data=entries[2], token=root_token)
-                # (honorary) Member, updated 18 Month ago
-                self.api.post("/users", data=entries[3], token=root_token)
+            for idx, entry in enumerate(entries):
+                with freeze_time(entry.get('updated')):
+                    user = {
+                        'nethz': f'pabloamiv{str(idx)}',
+                        'firstname': 'Pablo',
+                        'lastname': "AMIV",
+                        'email': f'pablo{str(idx)}@amiv.ch',
+                        'gender': 'male',
+                        'membership': entry.get('membership')
+                    }
+                    self.api.post("/users", data=user, token=root_token)
 
             users = self.api.get("/users", token=root_token).json
             self.assertEqual(len(users['_items']), 4)
 
-            with freeze_time("2019-12-24T14:15:22Z"):
+            with freeze_time(cleanup_time):
                 cleanup.remove_inactive_users()
 
             users = self.api.get("/users", token=root_token).json

--- a/amivapi/tests/users/test_user_cleanup.py
+++ b/amivapi/tests/users/test_user_cleanup.py
@@ -7,15 +7,10 @@
 Test if inactive non-members get deleted from database
 """
 
-from datetime import datetime, timedelta
-from lib2to3.pgen2 import token
-from signal import SIG_DFL
 from freezegun import freeze_time
 
-from amivapi import cron
 from amivapi.tests import utils
 from amivapi.users import cleanup
-
 
 
 class UserCleanupTest(utils.WebTest):
@@ -58,7 +53,7 @@ class UserCleanupTest(utils.WebTest):
         ]
 
         root_token = self.get_root_token()
-        
+
         with self.app.app_context():
             with freeze_time("2019-08-24T14:15:22Z"):
                 # Non-member, updated 6 Month ago
@@ -72,12 +67,12 @@ class UserCleanupTest(utils.WebTest):
                 # (honorary) Member, updated 18 Month ago
                 self.api.post("/users", data=entries[3], token=root_token)
 
-            users = self.api.get("/users", token=root_token ).json
+            users = self.api.get("/users", token=root_token).json
             self.assertEqual(len(users['_items']), 4)
 
             with freeze_time("2019-12-24T14:15:22Z"):
                 cleanup.remove_inactive_users()
 
-            users = self.api.get("/users", token=root_token ).json
+            users = self.api.get("/users", token=root_token).json
 
         self.assertEqual(len(users['_items']), 3)

--- a/amivapi/users/cleanup.py
+++ b/amivapi/users/cleanup.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# license: AGPLv3, see LICENSE for details. In addition we strongly encourage
+#          you to buy us beer if we meet and you like the software.
+"""Delete inactive users to keep the database clean"""
+
+from datetime import timedelta, datetime
+
+from amivapi.cron import periodic
+
+from flask import current_app as app
+
+@periodic(timedelta(days=28))
+def remove_inactive_users():
+    """Delete non-amiv-members, which were not active for more than one year"""
+    dueDate = datetime.now() - timedelta(days=365)
+
+    app.data.driver.db['users'].delete_many({'$and': [{'_updated':{'$lt': dueDate}}, 
+                                                {'membership':'none'}]})

--- a/amivapi/users/cleanup.py
+++ b/amivapi/users/cleanup.py
@@ -5,15 +5,15 @@
 """Delete inactive users to keep the database clean"""
 
 from datetime import timedelta, datetime
+from flask import current_app as app
 
 from amivapi.cron import periodic
 
-from flask import current_app as app
 
 @periodic(timedelta(days=28))
 def remove_inactive_users():
     """Delete non-amiv-members, which were not active for more than one year"""
     dueDate = datetime.now() - timedelta(days=365)
 
-    app.data.driver.db['users'].delete_many({'$and': [{'_updated':{'$lt': dueDate}}, 
-                                                {'membership':'none'}]})
+    app.data.driver.db['users'].delete_many(
+        {'$and': [{'_updated': {'$lt': dueDate}}, {'membership': 'none'}]})


### PR DESCRIPTION
The AMIV API currently has ~13'000 users. To keep the database clean, inactive users, i.e. non-members which didn't log in for the past 12 months, should be deleted from the database.