### PR TITLE
Ldap login without sync

### DIFF
--- a/amivapi/auth/sessions.py
+++ b/amivapi/auth/sessions.py
@@ -182,10 +182,10 @@ def process_login(items):
             # Success, sync user and get token
             try:
                 user = ldap.sync_one(username)
+                app.logger.info(
+                    "User '%s' was authenticated with LDAP" % username)
             except LDAPException:
                 # Sync failed! Try to find user in db.
-                app.logger.error(f"User '{username}' was authenticated, " +
-                                 "but could not be synced.")
                 user = _find_user(username)
                 if user:
                     app.logger.error(
@@ -199,8 +199,6 @@ def process_login(items):
                     abort(401, description=debug_error_message(status))
 
             _prepare_token(item, user['_id'])
-            app.logger.info(
-                "User '%s' was authenticated with LDAP" % username)
             return
 
         # Database, try to find via nethz, mail or objectid

--- a/amivapi/auth/sessions.py
+++ b/amivapi/auth/sessions.py
@@ -182,10 +182,10 @@ def process_login(items):
             # Success, sync user and get token
             try:
                 user = ldap.sync_one(username)
-                app.logger.info(
-                    "User '%s' was authenticated with LDAP" % username)
             except LDAPException:
                 # Sync failed! Try to find user in db.
+                app.logger.error(f"User '{username}' was authenticated, " +
+                                 "but could not be synced.")
                 user = _find_user(username)
                 if user:
                     app.logger.error(
@@ -199,6 +199,8 @@ def process_login(items):
                     abort(401, description=debug_error_message(status))
 
             _prepare_token(item, user['_id'])
+            app.logger.info(
+                "User '%s' was authenticated with LDAP" % username)
             return
 
         # Database, try to find via nethz, mail or objectid

--- a/amivapi/events/validation.py
+++ b/amivapi/events/validation.py
@@ -159,7 +159,8 @@ class EventValidator(object):
                             % event_id)
 
     def _validate_admin_or_moderator_only(self, enabled, field, value):
-        """Prohibit anyone except admins or event moderators from setting this field.
+        """Prohibit anyone except admins or event moderators from setting this
+        field.
 
         Applies to POST and PATCH.
 

--- a/amivapi/ldap.py
+++ b/amivapi/ldap.py
@@ -184,7 +184,7 @@ def _process_data(data):
     if is_member:
         res['send_newsletter'] = True
 
-    # Remove all keys with None value and 
+    # Remove all keys with None value
     keys_skipped = []
     for key in list(res.keys()):
         if res[key] is None:
@@ -193,8 +193,8 @@ def _process_data(data):
 
     if len(keys_skipped) > 0:
         current_app.logger.info(
-            "Skipped fields for LDAP sync for user '%s': %s" % \
-                res.get('nethz'), ','.join(keys_skipped))
+            "Skipped fields for LDAP sync for user '%s': %s" %
+            res.get('nethz'), ','.join(keys_skipped))
 
     return res
 

--- a/amivapi/ldap.py
+++ b/amivapi/ldap.py
@@ -184,8 +184,19 @@ def _process_data(data):
     if is_member:
         res['send_newsletter'] = True
 
-    # Remove all keys with None value before return
-    return {key: value for key, value in res.items() if value is not None}
+    # Remove all keys with None value and 
+    keys_skipped = []
+    for key in list(res.keys()):
+        if res[key] is None:
+            del res[key]
+            keys_skipped.append(key)
+
+    if len(keys_skipped) > 0:
+        current_app.logger.info(
+            "Skipped fields for LDAP sync for user '%s': %s" % \
+                res.get('nethz'), ','.join(keys_skipped))
+
+    return res
 
 
 def _create_or_update_user(ldap_data):

--- a/amivapi/ldap.py
+++ b/amivapi/ldap.py
@@ -194,7 +194,8 @@ def _process_data(data):
 
     if len(keys_skipped) > 0:
         current_app.logger.info(
-            "Skipped fields for LDAP sync for user '%s': %s" %
+            "The follow fields are missing in the LDAP response and "
+            "could not be synchronized for user '%s': %s" %
             (res.get('nethz'), ','.join(keys_skipped)))
 
     return res

--- a/amivapi/ldap.py
+++ b/amivapi/ldap.py
@@ -187,14 +187,15 @@ def _process_data(data):
     # Remove all keys with None value
     keys_skipped = []
     for key in list(res.keys()):
-        if res[key] is None:
+        # Key 'department' is allowed to be None
+        if res[key] is None and key != 'department':
             del res[key]
             keys_skipped.append(key)
 
     if len(keys_skipped) > 0:
         current_app.logger.info(
             "Skipped fields for LDAP sync for user '%s': %s" %
-            res.get('nethz'), ','.join(keys_skipped))
+            (res.get('nethz'), ','.join(keys_skipped)))
 
     return res
 

--- a/amivapi/tests/joboffers/test_joboffers.py
+++ b/amivapi/tests/joboffers/test_joboffers.py
@@ -19,7 +19,9 @@ class JobOffersTest(utils.WebTestNoAuth):
     """Test basic functionality of joboffers"""
 
     def test_add_joboffer_nomedia(self):
-        """ Usecase: A firm wants to post a joboffer on the website without any media
+        """
+        Usecase:
+        A firm wants to post a joboffer on the website withoutany media
         """
 
         time_end = (datetime.utcnow() + timedelta(days=2)).strftime(DATE_FORMAT)

--- a/amivapi/tests/utils.py
+++ b/amivapi/tests/utils.py
@@ -51,7 +51,7 @@ class TestClient(FlaskClient):
             })
 
         # Add content-type: json header if nothing else is provided
-        if (not("content-type" in kwargs['headers']) and
+        if (not ("content-type" in kwargs['headers']) and
                 ("data" in kwargs)):
             # Parse data
             kwargs['data'] = json.dumps(kwargs['data'])


### PR DESCRIPTION
If some LDAP fields are not present in the LDAP response of ETH, the whole user synchronization fails currently and the users cannot log in as described in #436 (Closes #436).

This PR ensures that the users can still successfully log in even if the user synchronization fails but the initial authentication with the LDAP server was successful.

The data processing of the LDAP response is made more failure tolerant. If a field which we expect to exist in the LDAP response is not available, we just skip processing that specific field but still handle the other fields. This makes it a bit harder to spot and debug potential issues with the LDAP sync.

If we want to make that more transparent, we could add further logging messages pointing out which fields were skipped.