### PR TITLE
Fix issue with CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    # Due to incompatibility of ubuntu-20.04 with mongo 5.0,
+    # Due to drop of out-of-the-box support in ubuntu-22.04 for MongoDB 5.0,
     # we cannot use ubuntu-latest.
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,14 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ['3.7', '3.10']
 
     services:
       mongodb:
-        image: mongo:5.0.8
+        image: mongo:5.0.14
         env:
           MONGO_INITDB_DATABASE: amivapi
         options: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   test:
+    # Due to incompatibility of ubuntu-20.04 with mongo 5.0,
+    # we cannot use ubuntu-latest.
     runs-on: ubuntu-20.04
     strategy:
       matrix:


### PR DESCRIPTION
Ubuntu-22.04 has no out-of-the-box support for Mongo 5. Therefore we keep using ubuntu-20.04.