### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.7', '3.10']
+        python-version: ['3.8', '3.10']
 
     services:
       mongodb:

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,11 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py310, flake8
+envlist = py38, py310, flake8
 
 [gh-actions]
 python =
-    3.7: py37
+    3.8: py38
     3.10: py310, flake8
 
 [testenv]


### PR DESCRIPTION
New version of some dependencies do not support Python 3.7 anymore. As we use a newer Python version anyway, we should drop this support too.