### PR TITLE
Add fields `external_registration` and `type` to the events resource

### DIFF
--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -133,6 +133,12 @@ signup:
     "SBB_Abo": "GA"
 }
 ```
+
+## External Registration
+
+There might be the case that the signup is organized by another organization or
+company. In this case, a link to the external signup can be set. It is not
+allowed to have "spots" > 0 and an external registration link at the same time.
 """)
 
 description_signups = ("""
@@ -380,7 +386,7 @@ eventdomain = {
                 'default': False,
             },
 
-            # Signups
+            # Signups / (external) Registration
 
             'spots': {
                 'title': 'Signup Spots',
@@ -458,6 +464,17 @@ eventdomain = {
                 'type': 'string',
                 'allowed': ['fcfs', 'manual'],
                 'default': 'fcfs',
+            },
+
+            'external_registration': {
+                'description': 'Link to an external registration for the '
+                                'advertised event. If used, `spots` must be '
+                                'set to `Null`.',
+                'type': 'string',
+                'nullable': True,
+                'default': None,
+                'url': True,
+                'only_if_null': 'spots'
             },
 
             'signup_count': {

--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -485,8 +485,8 @@ eventdomain = {
 
             'external_registration': {
                 'description': 'Link to an external registration for the '
-                                'advertised event. If used, `spots` must be '
-                                'set to `Null`.',
+                               'advertised event. If used, `spots` must be '
+                               'set to `Null`.',
                 'type': 'string',
                 'nullable': True,
                 'default': None,

--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -18,6 +18,14 @@ of and join.
 
 <br />
 
+## Type
+
+Events can be of different types. Events organized by another organization or
+company are of type `external`, otherwise they are `internal`. Announcements
+are events of type `announcement` as they are not events in a classical sense.
+
+<br />
+
 ## Moderator
 
 Events can have a *Moderator*. The Moderator can modify the events, and view
@@ -237,6 +245,15 @@ eventdomain = {
                 'type': 'string',
                 'maxlength': 10000,
                 'no_html': True,
+            },
+            'type': {
+                'description': 'Specifies what kind of event it is. This may '
+                               'be a regular event or a special announcement.',
+                'example': 'internal',
+                'type': 'string',
+                'required': True,
+                'nullable': False,
+                'allowed': ['announcement', 'internal', 'external'],
             },
             'location': {
                 'description': 'Where the event will take place.',
@@ -492,6 +509,7 @@ eventdomain = {
                 'readonly': True,
                 'type': 'integer'
             },
+
             'moderator': {
                 'description': '`_id` of a user which will be the event '
                                'moderator, who can modify the event.',

--- a/amivapi/events/validation.py
+++ b/amivapi/events/validation.py
@@ -351,7 +351,7 @@ class EventValidator(object):
             self.persisted_document.get(only_if_null) is not None)
 
         if ((only_if_null in doc and doc.get(only_if_null) is not None) or
-            (not (only_if_null in doc) and exists_in_original)):
+                (not (only_if_null in doc) and exists_in_original)):
             self._error(field, "May only be specified if %s is null"
                         % only_if_null)
 

--- a/amivapi/events/validation.py
+++ b/amivapi/events/validation.py
@@ -335,6 +335,26 @@ class EventValidator(object):
             self._error(field, "May only be specified if %s is not null"
                         % only_if_not_null)
 
+    def _validate_only_if_null(self, only_if_null, field, _):
+        """The field may only be set if another field is None.
+
+        Args:
+            only_if_null (string): The field, that may be None
+            field (string): name of the validated field
+
+        The rule's arguments are validated against this schema:
+        {'type': 'string'}
+        """
+        doc = self.document
+        exists_in_original = (  # Check original document in case of patches
+            self.persisted_document is not None and
+            self.persisted_document.get(only_if_null) is not None)
+
+        if ((only_if_null in doc and doc.get(only_if_null) is not None) or
+            (not (only_if_null in doc) and exists_in_original)):
+            self._error(field, "May only be specified if %s is null"
+                        % only_if_null)
+
     def _validate_no_user_mail(self, enabled, field, value):
         """Validate that the mail address does not belong to a user.
 

--- a/amivapi/tests/events/test_model.py
+++ b/amivapi/tests/events/test_model.py
@@ -32,6 +32,43 @@ class EventModelTest(WebTestNoAuth):
             'event': str(ev['_id']),
             'user': str(user['_id'])
         }, status_code=422)
+    
+    def test_external_registration(self):
+        """Test that internal and external registrations cannot be
+        used together."""
+        # Test valid internal and external events
+        self.api.post("/events",
+                      data=self.event_data(dict(
+                          spots=10,
+                          time_register_start='1970-01-01T00:00:01Z',
+                          time_register_end='2020-01-01T00:00:01Z',
+                          external_registration=None
+                      )),
+                      status_code=201)
+        self.api.post("/events",
+                      data=self.event_data(dict(
+                          spots=None, 
+                          external_registration='https://amiv.ethz.ch/test'
+                      )),
+                      status_code=201)
+
+        # Test for invalid url
+        self.api.post("/events",
+                      data=self.event_data(dict(
+                          spots=None, 
+                          external_registration='ftp://amiv.ethz.ch/test'
+                      )),
+                      status_code=422)
+        
+        # Test for external and internal registration in parallel
+        self.api.post("/events",
+                      data=self.event_data(dict(
+                          spots=10,
+                          time_register_start='1970-01-01T00:00:01Z',
+                          time_register_end='2020-01-01T00:00:01Z',
+                          external_registration='https://amiv.ethz.ch/test'
+                      )),
+                      status_code=422)
 
     def test_email_or_user(self):
         """A signup requires email XOR user."""

--- a/amivapi/tests/events/test_model.py
+++ b/amivapi/tests/events/test_model.py
@@ -20,6 +20,7 @@ class EventModelTest(WebTestNoAuth):
                     catchphrase_en='disco, disco, party, party',
                     time_advertising_start='1970-01-01T00:00:01Z',
                     time_advertising_end='2020-01-01T00:00:00Z',
+                    type='internal',
                     priority=5,
                     **data)
 
@@ -38,36 +39,36 @@ class EventModelTest(WebTestNoAuth):
         used together."""
         # Test valid internal and external events
         self.api.post("/events",
-                      data=self.event_data(dict(
-                          spots=10,
-                          time_register_start='1970-01-01T00:00:01Z',
-                          time_register_end='2020-01-01T00:00:01Z',
-                          external_registration=None
-                      )),
+                      data=self.event_data({
+                          'spots': 10,
+                          'time_register_start': '1970-01-01T00:00:01Z',
+                          'time_register_end': '2020-01-01T00:00:01Z',
+                          'external_registration': None
+                      }),
                       status_code=201)
         self.api.post("/events",
-                      data=self.event_data(dict(
-                          spots=None, 
-                          external_registration='https://amiv.ethz.ch/test'
-                      )),
+                      data=self.event_data({
+                          'spots': None, 
+                          'external_registration': 'https://amiv.ethz.ch/test'
+                      }),
                       status_code=201)
 
         # Test for invalid url
         self.api.post("/events",
-                      data=self.event_data(dict(
-                          spots=None, 
-                          external_registration='ftp://amiv.ethz.ch/test'
-                      )),
+                      data=self.event_data({
+                          'spots': None, 
+                          'external_registration': 'ftp://amiv.ethz.ch/test'
+                      }),
                       status_code=422)
         
         # Test for external and internal registration in parallel
         self.api.post("/events",
-                      data=self.event_data(dict(
-                          spots=10,
-                          time_register_start='1970-01-01T00:00:01Z',
-                          time_register_end='2020-01-01T00:00:01Z',
-                          external_registration='https://amiv.ethz.ch/test'
-                      )),
+                      data=self.event_data({
+                          'spots': 10,
+                          'time_register_start': '1970-01-01T00:00:01Z',
+                          'time_register_end': '2020-01-01T00:00:01Z',
+                          'external_registration': 'https://amiv.ethz.ch/test'
+                      }),
                       status_code=422)
 
     def test_email_or_user(self):

--- a/amivapi/tests/events/test_model.py
+++ b/amivapi/tests/events/test_model.py
@@ -33,7 +33,7 @@ class EventModelTest(WebTestNoAuth):
             'event': str(ev['_id']),
             'user': str(user['_id'])
         }, status_code=422)
-    
+
     def test_external_registration(self):
         """Test that internal and external registrations cannot be
         used together."""
@@ -48,7 +48,7 @@ class EventModelTest(WebTestNoAuth):
                       status_code=201)
         self.api.post("/events",
                       data=self.event_data({
-                          'spots': None, 
+                          'spots': None,
                           'external_registration': 'https://amiv.ethz.ch/test'
                       }),
                       status_code=201)
@@ -56,11 +56,11 @@ class EventModelTest(WebTestNoAuth):
         # Test for invalid url
         self.api.post("/events",
                       data=self.event_data({
-                          'spots': None, 
+                          'spots': None,
                           'external_registration': 'ftp://amiv.ethz.ch/test'
                       }),
                       status_code=422)
-        
+
         # Test for external and internal registration in parallel
         self.api.post("/events",
                       data=self.event_data({

--- a/amivapi/tests/test_validation.py
+++ b/amivapi/tests/test_validation.py
@@ -11,6 +11,7 @@ from amivapi.auth.auth import AmivTokenAuth
 from amivapi.tests.utils import WebTest, WebTestNoAuth
 from amivapi.validation import ValidatorAMIV
 
+
 class ValidatorAMIVTestNoAuth(WebTestNoAuth):
     """Unit test class for general purpose validators w/o authentication."""
 

--- a/amivapi/tests/test_validation.py
+++ b/amivapi/tests/test_validation.py
@@ -8,8 +8,69 @@
 from datetime import datetime, timedelta, timezone
 
 from amivapi.auth.auth import AmivTokenAuth
-from amivapi.tests.utils import WebTest
+from amivapi.tests.utils import WebTest, WebTestNoAuth
 from amivapi.validation import ValidatorAMIV
+
+class ValidatorAMIVTestNoAuth(WebTestNoAuth):
+    """Unit test class for general purpose validators w/o authentication."""
+
+    def test_validate_no_html(self):
+        """Test no-html validator."""
+        self.app.register_resource('test', {
+            'schema': {
+                'field': {
+                    'type': 'string',
+                    'no_html': True
+                }
+            }
+        })
+
+        has_html = '<head><title>I\'m title</title></head>Hello, <b>world</b>'
+        has_no_html = 'ich <3 du und="test" d:> ichht fldf d<'
+
+        self.api.post('/test', data={
+            'field': has_html
+        }, status_code=422)
+
+        self.api.post('/test', data={
+            'field': has_no_html
+        }, status_code=201)
+
+    def test_validate_url(self):
+        """Test url validator."""
+        self.app.register_resource('test', {
+            'schema': {
+                'field': {
+                    'type': 'string',
+                    'url': True
+                }
+            }
+        })
+
+        valid_urls = [
+            'http://amiv.ethz.ch/test',
+            'https://amiv.ethz.ch/test',
+            'https://amiv.ethz.ch/',
+            'http://amiv.ethz.ch/test#testAnchor'
+            'http://amiv.ethz.ch/test?param=yes'
+        ]
+        invalid_urls = [
+            'amiviscool',
+            'www.amiv.ethz.ch',
+            'www.amiv.ethz.ch/test',
+            'ftp://example.amiv.ethz.ch/'
+        ]
+
+        for valid_url in valid_urls:
+            print(valid_url)
+            self.api.post('/test', data={
+                'field': valid_url
+            }, status_code=201)
+
+        for invalid_url in invalid_urls:
+            self.api.post('/test', data={
+                'field': invalid_url
+            }, status_code=422)
 
 
 class ValidatorAMIVTest(WebTest):

--- a/amivapi/validation.py
+++ b/amivapi/validation.py
@@ -17,6 +17,7 @@ from imghdr import what
 from collections.abc import Hashable
 from PIL import Image
 from bs4 import BeautifulSoup
+from urllib.parse import urlparse
 
 from eve.io.mongo import Validator as Validator
 from flask import current_app as app
@@ -401,6 +402,22 @@ class ValidatorAMIV(Validator):
         if no_html and bool(BeautifulSoup(value, 'html.parser').find()):
             self._error(field, 'The text must not contain html elements.')
 
+    def _validate_url(self, url, field, value):
+        """Validation for a text field.
+
+        Validates that the provided text is a valid URL.
+
+        Args:
+            url (bool): if set to true, all text not being a valid URL will be
+                        rejected
+            field (string): field name
+            value: field value
+        """
+
+        if url:
+            result = urlparse(value)
+            if not all([result.scheme in ['http', 'https'], result.netloc, result.path]):
+                self._error(field, 'The text be a valid http(s) url.')
 
 # Cerberus uses a different validator for schemas, which is unaware of
 # custom types.

--- a/amivapi/validation.py
+++ b/amivapi/validation.py
@@ -416,8 +416,10 @@ class ValidatorAMIV(Validator):
 
         if url:
             result = urlparse(value)
-            if not all([result.scheme in ['http', 'https'], result.netloc, result.path]):
+            if not all([result.scheme in ['http', 'https'],
+                        result.netloc, result.path]):
                 self._error(field, 'The text be a valid http(s) url.')
+
 
 # Cerberus uses a different validator for schemas, which is unaware of
 # custom types.


### PR DESCRIPTION
The requirement emerged to have events organized solely by companies (with their own registration tool) listed on a separate page on the amiv website.

In order to be able to distinguish those different event types, a new field `type` is introduced which adds three different types of events:
| Type | Description |
| --------- | -------------------|
| `internal` | Events organized by amiv. These are the events as we have them so far in our system. |
| `external` | Events organized by companies which are listed on a completely separate page on the amiv website. |
| `announcement` | Special event type for future use to be able to show announcements on the amiv website and other infoscreens without showing them on the events page. |

In addition we also introduce the new field `external_registration` which accepts an URL pointing to an external registration website. This field cannot be used together with our internal registration tool.
The primary idea behind this field was to have the registration link for the external company events in a structured manner. But we do not want to limit this feature solely to external events, so it can also be used by other event types (e.g. Coding Weekend where the registration is hosted on the VIS website).
This new field accepts HTTP and HTTPS links only.

**Important Note**

As we introduce an new required field (`type`), we have to migrate the existing events to have that field. As we do not have any structure for automatic database migrations, we should run a data migration script when this feature is released to master and deployed on production.