### PR TITLE
Add `time_deregister_end` field to events resource

### DIFF
--- a/amivapi/events/authorization.py
+++ b/amivapi/events/authorization.py
@@ -51,6 +51,7 @@ class EventSignupAuth(AmivTokenAuth):
         # Remove tzinfo to compare to utcnow (API only accepts UTC anyways)
         time_register_start = event['time_register_start'].replace(tzinfo=None)
         time_register_end = event['time_register_end'].replace(tzinfo=None)
+        time_deregister_end = event['time_deregister_end'].replace(tzinfo=None)
 
         # Only the user itself can modify the item (not moderators), and only
         # within the signup window
@@ -58,7 +59,7 @@ class EventSignupAuth(AmivTokenAuth):
         return (user_id == str(event['moderator']) or
                 (('user' in item) and
                  (user_id == str(get_id(item['user']))) and
-                 (time_register_start <= dt.utcnow() <= time_register_end)))
+                 (time_register_start <= dt.utcnow() <= time_deregister_end)))
 
     def has_resource_write_permission(self, user_id):
         """Anyone can sign up. Further requirements are enforced with validators

--- a/amivapi/events/authorization.py
+++ b/amivapi/events/authorization.py
@@ -50,7 +50,6 @@ class EventSignupAuth(AmivTokenAuth):
 
         # Remove tzinfo to compare to utcnow (API only accepts UTC anyways)
         time_register_start = event['time_register_start'].replace(tzinfo=None)
-        time_register_end = event['time_register_end'].replace(tzinfo=None)
         time_deregister_end = event['time_deregister_end'].replace(tzinfo=None)
 
         # Only the user itself can modify the item (not moderators), and only

--- a/amivapi/events/emails.py
+++ b/amivapi/events/emails.py
@@ -67,7 +67,8 @@ def notify_signup_accepted(event, signup, waiting_list=False):
                 name=name,
                 title=event_name,
                 link=deletion_link,
-                deadline=event['time_register_end'].strftime('%H.%M %d.%m.%Y')),
+                deadline=event['time_deregister_end']
+                    .strftime('%H.%M %d.%m.%Y')),
              reply_to_email)
 
 

--- a/amivapi/events/emails.py
+++ b/amivapi/events/emails.py
@@ -67,8 +67,8 @@ def notify_signup_accepted(event, signup, waiting_list=False):
                 name=name,
                 title=event_name,
                 link=deletion_link,
-                deadline=event['time_deregister_end']
-                    .strftime('%H.%M %d.%m.%Y')),
+                deadline=(event['time_deregister_end']
+                          .strftime('%H.%M %d.%m.%Y'))),
              reply_to_email)
 
 

--- a/amivapi/events/model.py
+++ b/amivapi/events/model.py
@@ -394,7 +394,8 @@ eventdomain = {
 
                 # Dependencies only for fields without useful defaults
                 'dependencies': ['time_register_start',
-                                 'time_register_end'],
+                                 'time_register_end',
+                                 'time_deregister_end'],
                 'min': 0,
                 'nullable': True,
                 'default': None,
@@ -408,7 +409,7 @@ eventdomain = {
                 'type': 'datetime',
                 'nullable': True,
                 'default': None,
-                'dependencies': ['time_register_end'],
+                'dependencies': ['time_register_end', 'time_deregister_end'],
                 'earlier_than': 'time_register_end',
                 'only_if_not_null': 'spots'
             },
@@ -416,6 +417,18 @@ eventdomain = {
                 'title': 'Registration End',
                 'description': 'End of the registration window.',
                 'example': '2018-10-13T17:00:00Z',
+
+                'type': 'datetime',
+                'default': None,
+                'nullable': True,
+                'dependencies': ['time_register_start', 'time_deregister_end'],
+                'later_than': 'time_register_start',
+                'only_if_not_null': 'spots'
+            },
+            'time_deregister_end': {
+                'title': 'Deregistration End',
+                'description': 'End of the deregistration window.',
+                'example': '2018-10-12T17:00:00Z',
 
                 'type': 'datetime',
                 'default': None,

--- a/amivapi/tests/events/test_auth.py
+++ b/amivapi/tests/events/test_auth.py
@@ -221,7 +221,7 @@ class EventAuthTest(WebTest):
         with freeze_time(datetime(2017, 1, 1)):
             self.api.delete("/eventsignups/" + str(signup['_id']),
                             headers=etag, token=token, status_code=403)
-        
+
         # Slightly too late
         with freeze_time(datetime(2016, 12, 1)):
             self.api.delete("/eventsignups/" + str(signup['_id']),

--- a/amivapi/tests/events/test_auth.py
+++ b/amivapi/tests/events/test_auth.py
@@ -131,6 +131,7 @@ class EventAuthTest(WebTest):
         """Test that signups out of the registration window are rejected for
         unpriviledged users."""
         t_open = datetime(2016, 1, 1)
+        t_deregister = datetime(2016, 11, 1)
         t_close = datetime(2016, 12, 31)
 
         moderator = self.new_object("users")
@@ -138,6 +139,7 @@ class EventAuthTest(WebTest):
 
         ev = self.new_object("events", spots=100,
                              time_register_start=t_open,
+                             time_deregister_end=t_deregister,
                              time_register_end=t_close,
                              moderator=moderator['_id'])
         user = self.new_object("users")
@@ -183,10 +185,11 @@ class EventAuthTest(WebTest):
                 'user': str(user3['_id'])
             }, token=root_token, status_code=201)
 
-    def test_registration_window_signoff(self):
-        """Test that signoff out of the registration window are rejected for
+    def test_deregistration_window_signoff(self):
+        """Test that signoff out of the deregistration window are rejected for
         unpriviledged users."""
         t_open = datetime(2016, 1, 1)
+        t_deregister = datetime(2016, 11, 1)
         t_close = datetime(2016, 12, 31)
 
         moderator = self.new_object("users")
@@ -199,6 +202,7 @@ class EventAuthTest(WebTest):
 
         ev = self.new_object("events", spots=100,
                              time_register_start=t_open,
+                             time_deregister_end=t_deregister,
                              time_register_end=t_close,
                              moderator=moderator['_id'])
         signup = self.new_object("eventsignups", event=ev['_id'],
@@ -215,6 +219,11 @@ class EventAuthTest(WebTest):
 
         # Too late
         with freeze_time(datetime(2017, 1, 1)):
+            self.api.delete("/eventsignups/" + str(signup['_id']),
+                            headers=etag, token=token, status_code=403)
+        
+        # Slightly too late
+        with freeze_time(datetime(2016, 12, 1)):
             self.api.delete("/eventsignups/" + str(signup['_id']),
                             headers=etag, token=token, status_code=403)
 

--- a/amivapi/tests/events/test_model.py
+++ b/amivapi/tests/events/test_model.py
@@ -43,6 +43,7 @@ class EventModelTest(WebTestNoAuth):
                           'spots': 10,
                           'time_register_start': '1970-01-01T00:00:01Z',
                           'time_register_end': '2020-01-01T00:00:01Z',
+                          'time_deregister_end': '2019-01-01T00:00:01Z',
                           'external_registration': None
                       }),
                       status_code=201)
@@ -67,6 +68,7 @@ class EventModelTest(WebTestNoAuth):
                           'spots': 10,
                           'time_register_start': '1970-01-01T00:00:01Z',
                           'time_register_end': '2020-01-01T00:00:01Z',
+                          'time_deregister_end': '2019-01-01T00:00:01Z',
                           'external_registration': 'https://amiv.ethz.ch/test'
                       }),
                       status_code=422)

--- a/amivapi/tests/events/test_model.py
+++ b/amivapi/tests/events/test_model.py
@@ -188,6 +188,7 @@ class EventModelTest(WebTestNoAuth):
                 "additionalProperties": False,
                 'properties': {}})},
             {'time_register_start': '2016-10-17T21:11:14Z'},
+            {'time_deregister_end': '2016-10-18T18:11:14Z'},
             {'time_register_end': '2016-10-18T21:11:14Z'}
         ]
 

--- a/amivapi/tests/fixtures.py
+++ b/amivapi/tests/fixtures.py
@@ -258,12 +258,17 @@ class FixtureMixin(object):
                 obj['time_register_end'] = (
                     datetime.utcnow() + timedelta(
                         seconds=random.randint(0, 1000000)))
+                obj['time_deregister_end'] = (
+                    datetime.utcnow() + timedelta(
+                        seconds=random.randint(0, 1000000)))
             else:
                 if ('time_register_start' not in obj or
-                        'time_register_end' not in obj):
+                        'time_register_end' not in obj or
+                        'time_deregister_end' not in obj):
                     raise BadFixtureException(
-                        "Bad fixture: please specify either both "
-                        "time_register_start and time_register_end or none")
+                        "Bad fixture: please specify either all of "
+                        "time_register_start and time_register_end "
+                        "and time_deregister_end or none")
 
             obj.setdefault('allow_email_signup',
                            random.choice([True, False]))

--- a/amivapi/tests/fixtures.py
+++ b/amivapi/tests/fixtures.py
@@ -257,10 +257,10 @@ class FixtureMixin(object):
                         seconds=random.randint(0, 1000000)))
                 obj['time_register_end'] = (
                     datetime.utcnow() + timedelta(
-                        seconds=random.randint(0, 1000000)))
+                        seconds=random.randint(1500000, 2000000)))
                 obj['time_deregister_end'] = (
                     datetime.utcnow() + timedelta(
-                        seconds=random.randint(0, 1000000)))
+                        seconds=random.randint(1000000, 1500000)))
             else:
                 if ('time_register_start' not in obj or
                         'time_register_end' not in obj or

--- a/amivapi/tests/fixtures.py
+++ b/amivapi/tests/fixtures.py
@@ -267,7 +267,7 @@ class FixtureMixin(object):
                         'time_deregister_end' not in obj):
                     raise BadFixtureException(
                         "Bad fixture: please specify either all of "
-                        "time_register_start and time_register_end "
+                        "time_register_start, time_register_end "
                         "and time_deregister_end or none")
 
             obj.setdefault('allow_email_signup',

--- a/test_performance.py
+++ b/test_performance.py
@@ -102,6 +102,8 @@ def create_event():
         'time_register_start': datetime(1970, 1, 1).strftime(DATE_FORMAT),
         'time_register_end': (datetime.utcnow() +
                               timedelta(days=100)).strftime(DATE_FORMAT),
+        'time_deregister_end': (datetime.utcnow() +
+                              timedelta(days=100)).strftime(DATE_FORMAT),
         'allow_email_signup': True
     }
     return post(BASE_URL + '/events', json=data, auth=(ROOT_PW, '')).json()

--- a/test_performance.py
+++ b/test_performance.py
@@ -103,7 +103,7 @@ def create_event():
         'time_register_end': (datetime.utcnow() +
                               timedelta(days=100)).strftime(DATE_FORMAT),
         'time_deregister_end': (datetime.utcnow() +
-                              timedelta(days=100)).strftime(DATE_FORMAT),
+                              timedelta(days=80)).strftime(DATE_FORMAT),
         'allow_email_signup': True
     }
     return post(BASE_URL + '/events', json=data, auth=(ROOT_PW, '')).json()


### PR DESCRIPTION
The requirement emerged to have different signup and signoff deadlines, so that users can still signoff when users cannot signoff themselves anymore.

**Important Note**
The new field is required if a registration window is given. This means that the existing data has to be migrated when deploying this feature.
