### PR TITLE
Issue 493: Fix missing email notifications on manual waitlist updates

### DIFF
--- a/amivapi/events/__init__.py
+++ b/amivapi/events/__init__.py
@@ -30,6 +30,7 @@ from amivapi.events.projections import (
 )
 from amivapi.events.queue import (
     add_accepted_before_insert,
+    notify_users_after_update,
     update_waiting_list_after_delete,
     update_waiting_list_after_insert,
 )
@@ -71,5 +72,8 @@ def init_app(app):
     app.on_inserted_eventsignups += update_waiting_list_after_insert
     app.on_deleted_item_eventsignups += notify_signup_deleted
     app.on_deleted_item_eventsignups += update_waiting_list_after_delete
+
+    # Notify users on manual updates
+    app.on_updated_eventsignups += notify_users_after_update
 
     app.register_blueprint(email_blueprint)

--- a/amivapi/events/queue.py
+++ b/amivapi/events/queue.py
@@ -109,3 +109,15 @@ def update_waiting_list_after_delete(signup):
         return
 
     update_waiting_list(signup['event'])
+
+
+def notify_users_after_update(signup_updates, original_signup):
+    """Hook to notify users after a signup is updated."""
+    if signup_updates.get('accepted') and not original_signup.get('accepted'):
+        # User was on the waitinglist and got accepted: Notify him
+        lookup = {current_app.config['ID_FIELD']: original_signup.get('event')}
+        event = current_app.data.find_one('events', None, **lookup)
+        if event is not None:
+            new_signup = original_signup.copy()
+            new_signup.update(signup_updates)
+            notify_signup_accepted(event, new_signup, False)

--- a/amivapi/tests/events/test_emails.py
+++ b/amivapi/tests/events/test_emails.py
@@ -304,18 +304,18 @@ class EventMailTest(WebTestNoAuth):
         updates his signup acceptance."""
         # Case 1: Manual Event with waiting list
         manual_event = self.new_object('events',
-                                spots=100,
-                                selection_strategy='manual',
-                                allow_email_signup=True)
+                                       spots=100,
+                                       selection_strategy='manual',
+                                       allow_email_signup=True)
         manual_user = self.new_object('users')
 
         # User put on waiting list
         manual_signup = self.api.post('/eventsignups',
-                                data={
-                                    'user': str(manual_user['_id']),
-                                    'event': str(manual_event['_id'])
-                                },
-                                status_code=201).json
+                                      data={
+                                          'user': str(manual_user['_id']),
+                                          'event': str(manual_event['_id'])
+                                      },
+                                      status_code=201).json
         self.assertTrue('was rejected' in self.app.test_mails[0]['text'])
 
         # User manually accepted from waiting list
@@ -335,13 +335,12 @@ class EventMailTest(WebTestNoAuth):
                                      selection_strategy='fcfs',
                                      allow_email_signup=True)
         # User accepted
-        self.api.post(
-            '/eventsignups',
-            data={
-                'user': str(fcfc_user_accepted['_id']),
-                'event': str(fcfc_event['_id'])
-            },
-            status_code=201)
+        self.api.post('/eventsignups',
+                      data={
+                          'user': str(fcfc_user_accepted['_id']),
+                          'event': str(fcfc_event['_id'])
+                      },
+                      status_code=201)
         self.assertTrue('was accepted' in self.app.test_mails[2]['text'])
 
         # User put on waiting list

--- a/amivapi/tests/events/test_emails.py
+++ b/amivapi/tests/events/test_emails.py
@@ -298,3 +298,66 @@ class EventMailTest(WebTestNoAuth):
 
         mail = self.app.test_mails[0]
         self.assertTrue(text in mail['text'])
+
+    def test_notify_waitlist_on_signup_update(self):
+        """Test that users on the waiting list get notified when a moderator
+        updates his signup acceptance."""
+        # Case 1: Manual Event with waiting list
+        manual_event = self.new_object('events',
+                                spots=100,
+                                selection_strategy='manual',
+                                allow_email_signup=True)
+        manual_user = self.new_object('users')
+
+        # User put on waiting list
+        manual_signup = self.api.post('/eventsignups',
+                                data={
+                                    'user': str(manual_user['_id']),
+                                    'event': str(manual_event['_id'])
+                                },
+                                status_code=201).json
+        self.assertTrue('was rejected' in self.app.test_mails[0]['text'])
+
+        # User manually accepted from waiting list
+        self.api.patch('/eventsignups/%s' % manual_signup['_id'],
+                       data={'accepted': True},
+                       status_code=200,
+                       headers={'If-Match': manual_signup['_etag']})
+        self.assertTrue('was accepted' in self.app.test_mails[1]['text'])
+
+        # Case 2: Full FCFS event with waiting list: User deregistered after
+        # deregistration deadline by contacting moderators and they
+        # manually accept a new user
+        fcfc_user_accepted = self.new_object('users')
+        fcfc_user_waitlist = self.new_object('users')
+        fcfc_event = self.new_object('events',
+                                     spots=1,
+                                     selection_strategy='fcfs',
+                                     allow_email_signup=True)
+        # User accepted
+        self.api.post(
+            '/eventsignups',
+            data={
+                'user': str(fcfc_user_accepted['_id']),
+                'event': str(fcfc_event['_id'])
+            },
+            status_code=201)
+        self.assertTrue('was accepted' in self.app.test_mails[2]['text'])
+
+        # User put on waiting list
+        fcfc_signup_waitlist = self.api.post(
+            '/eventsignups',
+            data={
+                'user': str(fcfc_user_waitlist['_id']),
+                'event': str(fcfc_event['_id'])
+            },
+            status_code=201).json
+        print(self.app.test_mails[2]['text'])
+        self.assertTrue('was rejected' in self.app.test_mails[3]['text'])
+
+        # User manually accepted from waiting list
+        self.api.patch('/eventsignups/%s' % fcfc_signup_waitlist['_id'],
+                       data={'accepted': True},
+                       headers={'If-Match': fcfc_signup_waitlist['_etag']},
+                       status_code=200)
+        self.assertTrue('was accepted' in self.app.test_mails[4]['text'])


### PR DESCRIPTION
Tackling issue #493 of missing notifications if eventsignups items are updated via PATCH requests. The corresponding hook was missing. 