### PR TITLE
Rewrite Waiting List Email

### DIFF
--- a/amivapi/templates/events_waitingList.html
+++ b/amivapi/templates/events_waitingList.html
@@ -3,8 +3,8 @@
 {% block text_german %}
   <p>Hey {{ name }}!</p>
 
-  <p>Leider müssten wir dich informieren, dass deine Anmeldung für {{ title_de }} abgelehnt wurde, weil keine freien Plätze mehr verfügbar sind.</p>
-  <p>Wir haben dich auf die Warteliste gesetzt und schicken dir eine E-Mail, sobald wieder ein Platz frei wird.</p>
+  <p>Du bist auf der Warteliste für {{ title_de }}, da das Event entweder ausgebucht ist, oder die Eventmoderation deine Anmeldung zuerst akzeptieren muss.</p>
+  <p>Wir senden dir eine weitere E-mail, wenn du für das Event akzeptiert wirst.</p>
 
   <p>Freundliche Grüsse,</br>AMIV</p>
 {% endblock %}
@@ -12,8 +12,8 @@
 {% block text_english %}
   <p>Hello {{ name }}!</p>
 
-  <p>We are sorry to inform you that your signup for {{ title_en }} was rejected because there are no free spots available.</p>
-  <p>We put you on a waiting list and we will send you an email when a spot becomes available.</p>
+  <p>You are now on the waiting list for {{ title_en }} because the event is either fully booked or the event moderator has to accept your signup first.</p>
+  <p>We'll send you another email if you get accepted for the event.</p>
 
   <p>Best Regards,</br>AMIV</p>
 {% endblock %}

--- a/amivapi/templates/events_waitingList.txt
+++ b/amivapi/templates/events_waitingList.txt
@@ -3,8 +3,8 @@
 {% block text_german %}
 Hey {{ name }}!
 
-Leider müssten wir dich informieren, dass deine Anmeldung für {{ title_de }} abgelehnt wurde, weil keine freien Plätze mehr verfügbar sind.
-Wir haben dich auf die Warteliste gesetzt und schicken dir eine E-Mail, sobald wieder ein Platz frei wird.
+Du bist auf der Warteliste für {{ title_de }}, da das Event entweder ausgebucht ist, oder die Eventmoderation deine Anmeldung zuerst akzeptieren muss. 
+Wir senden dir eine weitere E-mail, wenn du für das Event akzeptiert wirst.
 
 Freundliche Grüsse,
 AMIV
@@ -13,8 +13,8 @@ AMIV
 {% block text_english %}
 Hello {{ name }}!    
 
-We are sorry to inform you that your signup for {{ title_en }} was rejected because there are no free spots available.
-We put you on a waiting list and we will send you an email when a spot becomes available.
+You are now on the waiting list for {{ title_en }} because the event is either fully booked or the event moderator has to accept your signup first.
+We'll send you another email if you get accepted for the event.
 
 Best Regards,
 AMIV


### PR DESCRIPTION
There's two cases why a user would receive the "events_waitignList" email:

1. The event is full. In this case, they end up on the waiting list and can be accepted if people sign off.
2. The event moderator has to approve of the participants, and thus all users end up on the waiting list.

The current text reads as follows:

```
Hello {{ name }}!

We are sorry to inform you that your signup for {{ event }} was rejected because there are no free spots available.

We put you on a waiting list and we will send you an email when a spot becomes available.

Best Regards,
AMIV
```

This text is well-suited for case 1, but very confusing for case 2. I got confused twice within one month about this now, so I'm creating a PR.