### PR TITLE
Send a different email for waitinglist on manually accepted events

### DIFF
--- a/amivapi/events/emails.py
+++ b/amivapi/events/emails.py
@@ -28,7 +28,11 @@ def find_reply_to_email(event):
     return current_app.config.get('DEFAULT_EVENT_REPLY_TO')
 
 
-def notify_signup_accepted(event, signup, waiting_list=False, spots_available=False):
+def notify_signup_accepted(
+        event,
+        signup,
+        waiting_list=False,
+        spots_available=False):
     """Send an email to a user that his signup was accepted"""
     id_field = current_app.config['ID_FIELD']
 

--- a/amivapi/events/emails.py
+++ b/amivapi/events/emails.py
@@ -28,7 +28,7 @@ def find_reply_to_email(event):
     return current_app.config.get('DEFAULT_EVENT_REPLY_TO')
 
 
-def notify_signup_accepted(event, signup, waiting_list=False):
+def notify_signup_accepted(event, signup, waiting_list=False, spots_available=False):
     """Send an email to a user that his signup was accepted"""
     id_field = current_app.config['ID_FIELD']
 
@@ -84,16 +84,28 @@ def notify_signup_accepted(event, signup, waiting_list=False):
         calendar_invite = None
 
     if waiting_list:
-        mail_from_template(
-            to=[email],
-            subject='Your signup for %s was put on the waiting list'
-                    % (title_en or title_de),
-            template_name='events_waitingList',
-            template_args=dict(
-                name=name,
-                title_en=(title_en or title_de),
-                title_de=(title_de or title_en)),
-            reply_to=reply_to_email)
+        if spots_available:
+            mail_from_template(
+                to=[email],
+                subject='Your signup for %s was put on the waiting list'
+                        % (title_en or title_de),
+                template_name='events_waitingListManual',
+                template_args=dict(
+                    name=name,
+                    title_en=(title_en or title_de),
+                    title_de=(title_de or title_en)),
+                reply_to=reply_to_email)
+        else:
+            mail_from_template(
+                to=[email],
+                subject='Your signup for %s was put on the waiting list'
+                        % (title_en or title_de),
+                template_name='events_waitingList',
+                template_args=dict(
+                    name=name,
+                    title_en=(title_en or title_de),
+                    title_de=(title_de or title_en)),
+                reply_to=reply_to_email)
     else:
         mail_from_template(
             to=[email],

--- a/amivapi/events/queue.py
+++ b/amivapi/events/queue.py
@@ -101,11 +101,11 @@ def update_waiting_list_after_insert(signups):
                 event = current_app.data.find_one('events', None, **lookup)
                 lookup = {'event': event_id, 'accepted': True}
                 signup_count = (
-                    current_app.data.driver.db['eventsignups']\
-                        .count_documents(lookup))
+                    current_app.data.driver.db['eventsignups']
+                    .count_documents(lookup))
                 if event is not None:
                     if event['selection_strategy'] == "manual" \
-                        and signup_count < event['spots']:
+                            and signup_count < event['spots']:
                         notify_signup_accepted(event, signup, True, True)
                     else:
                         notify_signup_accepted(event, signup, True, False)

--- a/amivapi/events/queue.py
+++ b/amivapi/events/queue.py
@@ -96,10 +96,17 @@ def update_waiting_list_after_insert(signups):
             if signup['_id'] in accepted:
                 signup['accepted'] = True
             elif signup.get('user') is not None:
-                lookup = {current_app.config['ID_FIELD']: signup.get('event')}
+                event_id = signup.get('event')
+                lookup = {current_app.config['ID_FIELD']: event_id}
                 event = current_app.data.find_one('events', None, **lookup)
+                lookup = {'event': event_id, 'accepted': True}
+                signup_count = (
+                    current_app.data.driver.db['eventsignups'].count_documents(lookup))
                 if event is not None:
-                    notify_signup_accepted(event, signup, True)
+                    if event['selection_strategy'] == "manual" and signup_count < event['spots']:
+                        notify_signup_accepted(event, signup, True, True)
+                    else:
+                        notify_signup_accepted(event, signup, True, False)
 
 
 def update_waiting_list_after_delete(signup):

--- a/amivapi/events/queue.py
+++ b/amivapi/events/queue.py
@@ -101,9 +101,11 @@ def update_waiting_list_after_insert(signups):
                 event = current_app.data.find_one('events', None, **lookup)
                 lookup = {'event': event_id, 'accepted': True}
                 signup_count = (
-                    current_app.data.driver.db['eventsignups'].count_documents(lookup))
+                    current_app.data.driver.db['eventsignups']\
+                        .count_documents(lookup))
                 if event is not None:
-                    if event['selection_strategy'] == "manual" and signup_count < event['spots']:
+                    if event['selection_strategy'] == "manual" \
+                        and signup_count < event['spots']:
                         notify_signup_accepted(event, signup, True, True)
                     else:
                         notify_signup_accepted(event, signup, True, False)

--- a/amivapi/templates/events_waitingListManual.html
+++ b/amivapi/templates/events_waitingListManual.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block text_german %}
+  <p>Hey {{ name }}!</p>
+
+  <p>Deine Anmeldung für {{ title_de }} wurde auf die Warteliste gesetzt, da bei diesem Event die Teilnehmer manuell akzeptiert werden.</p>
+  <p>Du erhältst eine E-Mail sobald deine Anmeldung definitiv aufgenommen wird.</p>
+
+  <p>Freundliche Grüsse,</br>AMIV</p>
+{% endblock %}
+
+{% block text_english %}
+  <p>Hello {{ name }}!</p>
+
+  <p>Your signup for {{ title_en }} was put on the waiting list, as the signups for this event are manually reviewed.</p>
+  <p>You will be notified as soon as your signup has been definitively accepted.</p>
+
+  <p>Best Regards,</br>AMIV</p>
+{% endblock %}

--- a/amivapi/templates/events_waitingListManual.txt
+++ b/amivapi/templates/events_waitingListManual.txt
@@ -1,0 +1,21 @@
+{% extends "base.txt" %}
+
+{% block text_german %}
+Hey {{ name }}!
+
+Deine Anmeldung für {{ title_de }} wurde auf die Warteliste gesetzt, da bei diesem Event die Teilnehmer manuell akzeptiert werden.
+Du erhältst eine E-Mail sobald deine Anmeldung definitiv aufgenommen wird.
+
+Freundliche Grüsse,
+AMIV
+{% endblock %}
+
+{% block text_english %}
+Hello {{ name }}!    
+
+Your signup for {{ title_en }} was put on the waiting list, as the signups for this event are manually reviewed.
+You will be notified as soon as your signup has been definitively accepted.
+
+Best Regards,
+AMIV
+{% endblock %}

--- a/amivapi/tests/events/test_emails.py
+++ b/amivapi/tests/events/test_emails.py
@@ -440,7 +440,8 @@ class EventMailTest(WebTestNoAuth):
                                           'event': str(manual_event['_id'])
                                       },
                                       status_code=201).json
-        self.assertTrue('was rejected' in self.app.test_mails[0]['text'])
+        # this results in a different email
+        self.assertTrue('are manually reviewed' in self.app.test_mails[0]['text'])
 
         # User manually accepted from waiting list
         self.api.patch('/eventsignups/%s' % manual_signup['_id'],

--- a/amivapi/tests/events/test_emails.py
+++ b/amivapi/tests/events/test_emails.py
@@ -441,7 +441,8 @@ class EventMailTest(WebTestNoAuth):
                                       },
                                       status_code=201).json
         # this results in a different email
-        self.assertTrue('are manually reviewed' in self.app.test_mails[0]['text'])
+        self.assertTrue('are manually reviewed'
+                        in self.app.test_mails[0]['text'])
 
         # User manually accepted from waiting list
         self.api.patch('/eventsignups/%s' % manual_signup['_id'],


### PR DESCRIPTION
Send a different email if a person is put on the waitinglist for an event with manual acceptance that still has free spots.
This essentially fixes the same problem as #624 but with different emails, which I only noticed after I had already implemented the changes.